### PR TITLE
Faceting

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -508,7 +508,10 @@ class Solr(object):
     def search(self, q, **kwargs):
         """Performs a search and returns the results."""
         params = {'q': q}
-        params.update(kwargs)
+        params.update(
+            (key.replace('_', '.'),
+             str(value).lower() if isinstance(value, bool) else value)
+            for (key, value) in kwargs.iteritems())
         response = self._select(params)
         
         # TODO: make result retrieval lazy and allow custom result objects


### PR DESCRIPTION
This commit adds support for using `bool` values as arguments to `search()`, as well as faceting parameters. Faceting is supported by replacing underscores in argument names with periods.

For example, this query was impossible to send before:

```
Solr(SOLR_HOST).search(q='*:*', rows=0, facet="true", facet_count=-1, facet_field="owner")
```

While I don't see Solr params which contain underscores, it’s possible that they exist; if that’s the case, they will break. If you feel this is a significant risk, I would have no problem with altering the code to only perform the replacement if, for example, the param name contained “facet.”
