### PR TITLE
Make it possible to access debug data when doing Solr queries.

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -225,9 +225,10 @@ class SolrError(Exception):
 
 
 class Results(object):
-    def __init__(self, docs, hits, highlighting=None, facets=None, spellcheck=None, stats=None):
+    def __init__(self, docs, hits, debug=None, highlighting=None, facets=None, spellcheck=None, stats=None):
         self.docs = docs
         self.hits = hits
+        self.debug = debug or {}
         self.highlighting = highlighting or {}
         self.facets = facets or {}
         self.spellcheck = spellcheck or {}
@@ -522,6 +523,9 @@ class Solr(object):
         # TODO: make result retrieval lazy and allow custom result objects
         result = self.decoder.decode(response)
         result_kwargs = {}
+
+        if result.get('debug'):
+            result_kwargs['debug'] = result['debug']
         
         if result.get('highlighting'):
             result_kwargs['highlighting'] = result['highlighting']


### PR DESCRIPTION
Added support for getting at the Solr querying debug data when using search(). (passing debugQuery=true as keyword arg the search() method will activate this property in the JSON results.

The folks I'm working with needed access to the debug data as part of regression test suite they are putting together. The change I made adds a debug property to the Result object much like how highlighting, facets, spellcheck or stats works.
