### PR TITLE
Change for Python 2.4 compatibility

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -768,7 +768,7 @@ class Solr(object):
             raise ValueError("extract() requires file-like objects which have a defined name property")
 
         params = {
-            "extractOnly": "true" if extractOnly else "false",
+            "extractOnly": extractOnly and "true" or "false",
             "lowernames": "true",
             "wt": "json",
             # We'll provide the file using its true name as Tika may use that


### PR DESCRIPTION
Greetings,

I made a small change to be able to use pysolr with Plone 3. It removes a syntax error.
This inline notation is safe to use here.

It would really help if it can be included and released in pypi.

Thanks !
