### PR TITLE
Update to SolrCoreAdmin create method incorrect action 

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -847,7 +847,7 @@ class SolrCoreAdmin(object):
     def create(self, name, instance_dir=None, config='solrcofig.xml', schema='schema.xml'):
         """http://wiki.apache.org/solr/CoreAdmin#head-7ca1b98a9df8b8ca0dcfbfc49940ed5ac98c4a08"""
         params = {
-            'action': 'STATUS',
+            'action': 'CREATE',
             'name': name,
             'config': config,
             'schema': schema,


### PR DESCRIPTION
It currently has:

``` python
        params = {
            'action': 'STATUS',
            'name': name,
            'config': config,
            'schema': schema,
        }
```

It should be:

``` python
        params = {
            'action': 'CREATE',
            'name': name,
            'config': config,
            'schema': schema,
        }
```
