### PR TITLE
Sentry friendly logging

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -306,15 +306,17 @@ class Solr(object):
 
             try:
                 start_time = time.time()
-                self.log.debug("Starting request to '%s' (%s) with body '%s'..." % (url, method, str(body)[:10]))
+                self.log.debug("Starting request to '%s' (%s) with body '%s'...",
+                               url, method, str(body)[:10])
                 headers, response = http.request(url, method=method, body=body, headers=headers)
                 end_time = time.time()
-                self.log.info("Finished '%s' (%s) with body '%s' in %0.3f seconds." % (url, method, str(body)[:10], end_time - start_time))
+                self.log.info("Finished '%s' (%s) with body '%s' in %0.3f seconds.",
+                              url, method, str(body)[:10], end_time - start_time)
             except AttributeError:
-                # For httplib2.
-                error_message = "Failed to connect to server at '%s'. Are you sure '%s' is correct? Checking it in a browser might help..." % (url, self.base_url)
-                self.log.error(error_message)
-                raise SolrError(error_message)
+                error_message = "Failed to connect to server at '%s'. Are you sure '%s' is correct? Checking it in a browser might help..."
+                params = (url, self.base_url)
+                self.log.error(error_message, *params)
+                raise SolrError(error_message % params)
 
             if int(headers['status']) != 200:
                 error_message = self._extract_error(headers, response)
@@ -332,11 +334,13 @@ class Solr(object):
                 conn = HTTPSConnection(self.host, self.port)
 
             start_time = time.time()
-            self.log.debug("Starting request to '%s:%s/%s' (%s) with body '%s'..." % (self.host, self.port, path, method, str(body)[:10]))
+            self.log.debug("Starting request to '%s:%s/%s' (%s) with body '%s'...",
+                           self.host, self.port, path, method, str(body)[:10])
             conn.request(method, path, body, headers)
             response = conn.getresponse()
             end_time = time.time()
-            self.log.info("Finished '%s:%s/%s' (%s) with body '%s' in %0.3f seconds." % (self.host, self.port, path, method, str(body)[:10], end_time - start_time))
+            self.log.info("Finished '%s:%s/%s' (%s) with body '%s' in %0.3f seconds.",
+                          self.host, self.port, path, method, str(body)[:10], end_time - start_time)
 
             if response.status != 200:
                 error_message = self._extract_error(dict(response.getheaders()), response.read())
@@ -585,7 +589,7 @@ class Solr(object):
         if 'QTime' in result.get('responseHeader', {}):
             result_kwargs['qtime'] = result['responseHeader']['QTime']
 
-        self.log.debug("Found '%s' search results." % result['response']['numFound'])
+        self.log.debug("Found '%s' search results.", result['response']['numFound'])
         return Results(result['response']['docs'], result['response']['numFound'], **result_kwargs)
 
     def more_like_this(self, q, mltfl, **kwargs):
@@ -609,7 +613,7 @@ class Solr(object):
                 'numFound': 0,
             }
 
-        self.log.debug("Found '%s' MLT results." % result['response']['numFound'])
+        self.log.debug("Found '%s' MLT results.", result['response']['numFound'])
         return Results(result['response']['docs'], result['response']['numFound'])
 
     def suggest_terms(self, fields, prefix, **kwargs):
@@ -703,7 +707,7 @@ class Solr(object):
 
         m = ET.tostring(message, encoding='utf-8')
         end_time = time.time()
-        self.log.debug("Built add request of %s docs in %0.2f seconds." % (len(docs), end_time - start_time))
+        self.log.debug("Built add request of %s docs in %0.2f seconds.", len(docs), end_time - start_time)
         response = self._update(m, commit=commit, waitFlush=waitFlush, waitSearcher=waitSearcher)
 
     def delete(self, id=None, q=None, commit=True, waitFlush=None, waitSearcher=None):


### PR DESCRIPTION
I've been working to purge the remaining parts of our logging stack where string interpolation happens as part of the logging call so Sentry can aggregate messages more intelligently.

(I'm a little surprised @dcramer didn't make it here first)
