### PR TITLE
Add 'description' to the scraped error message from tomcat.

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -458,6 +458,12 @@ class Solr(object):
                 if len(children) >= 2 and 'message' in children[0].renderContents().lower():
                     reason = children[1].renderContents()
 
+                if len(children) >= 2 and 'description' in children[0].renderContents().lower():
+                    if reason is None:
+                        reason = children[1].renderContents()
+                    else:
+                        reason += ", " + children[1].renderContents()
+
             if reason is None:
                 full_html = soup.prettify()
         else:


### PR DESCRIPTION
This is a small change to try and make the error a bit more descriptive. It changes error messages from (for example);

```
SolrError: [Reason: /solr/mlt/]
```

To;

```
SolrError: [Reason: /solr/mlt/, The requested resource (/solr/mlt/) is not available.]
```

When pysolr hits urls like this;

![screen grab](http://f.cl.ly/items/0h3N2T0j3F3D2823470t/Screen%20Shot%202012-05-19%20at%2015.29.39.png)

Couple of questions;
1. I'm not sure how best to test this.
2. In this case the HTTP status code (404) would be useful to know. Should it be included too?
