### PR TITLE
Extended error logging

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -476,6 +476,8 @@ class Solr(object):
                 # html page might be different for every server
                 if server_type == 'jetty':
                     reason_node = dom_tree.find('body/pre')
+                else:
+                    reason_node = dom_tree.find('head/title')
 
                 if reason_node is not None:
                     reason = reason_node.text


### PR DESCRIPTION
A batch of "[Reason: None]" messages in Sentry inspired me to add some more
logging context. Now the full headers & response body will be passed as logging
extra data so handlers like Raven can see them.

Additionally, I found that my Solr 3.6 / Jetty install broke the previous
scraping heuristic so I added a fallback to the HTML title for the returned
summary so it's not necessary to dig into the details for many failures
