### PR TITLE
Added MoreLikeThis handler to solrconfig.xml test cores.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,8 @@ Setup looks like::
     # Fix paths for the content extraction handler:
     perl -p -i -e 's|<lib dir="../../../contrib/|<lib dir="../../contrib/|'g solr/*/conf/solrconfig.xml
     perl -p -i -e 's|<lib dir="../../../dist/|<lib dir="../../dist/|'g solr/*/conf/solrconfig.xml
+    # Add MoreLikeThis handler
+    perl -p -i -e 's|<!-- A Robust Example|<!-- More like this request handler -->\n  <requestHandler name="/mlt" class="solr.MoreLikeThisHandler" />\n\n\n  <!-- A Robust Example|'g solr/*/conf/solrconfig.xml
     # Now run Solr.
     java -jar start.jar
 


### PR DESCRIPTION
The MoreLikeThis handler is missing in solrconfig.xml by default leading to 2 broken tests. Here's the stacktrace:

```
$ python -m unittest2 tests
...............E............E........
====================================================================
ERROR: test__mlt (tests.client.SolrTestCase)
--------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/client.py", line 205, in test__mlt
    resp_body = self.solr._mlt({'q': 'id:doc_1', 'mlt.fl': 'title'})
  File "pysolr.py", line 317, in _mlt
    return self._send_request('get', path)
  File "pysolr.py", line 292, in _send_request
    raise SolrError(error_message)
SolrError: [Reason: Error 404 Not Found]

====================================================================
ERROR: test_more_like_this (tests.client.SolrTestCase)
--------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/client.py", line 320, in test_more_like_this
    results = self.solr.more_like_this('id:doc_1', 'text')
  File "pysolr.py", line 620, in more_like_this
    response = self._mlt(params)
  File "pysolr.py", line 317, in _mlt
    return self._send_request('get', path)
  File "pysolr.py", line 292, in _send_request
    raise SolrError(error_message)
SolrError: [Reason: Error 404 Not Found]

--------------------------------------------------------------------
Ran 37 tests in 5.422s

FAILED (errors=2)
```
