### PR TITLE
Trailing slash in the base URL will break reqeusts

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -232,7 +232,7 @@ class Solr(object):
 
     def _create_full_url(self, path=''):
         if len(path):
-            return '/'.join([self.url, path.lstrip('/')])
+            return '/'.join([self.url.rstrip('/'), path.lstrip('/')])
 
         # No path? No problem.
         return self.url

--- a/tests/client.py
+++ b/tests/client.py
@@ -440,3 +440,10 @@ class SolrTestCase(unittest.TestCase):
         # correctly decoded entities and that our UTF-8 characters survived the
         # round-trip:
         self.assertEqual(['Test Title ☃☃'], m['title'])
+
+    def test_full_url(self):
+        self.solr.url = 'http://localhost:8983/solr/'
+        full_url = self.solr._create_full_url(path='/update')
+
+        # Make sure trailing and leading slashes do not collide:
+        self.assertEqual(full_url, 'http://localhost:8983/solr/update')


### PR DESCRIPTION
In addition to removing the leading slash from the path, this pull request also removes the trailing slash from the root URL.
