### PR TITLE
SolrCoreAdmin nonfunctional

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -928,7 +928,8 @@ class SolrCoreAdmin(SolrRequestHandler):
 
         return self._get_url(params=params)
 
-    def create(self, name, instance_dir=None, config=None, schema=None):
+    def create(self, name, instance_dir=None, config=None, schema=None,
+            data_dir=None):
         """http://wiki.apache.org/solr/CoreAdmin#head-7ca1b98a9df8b8ca0dcfbfc49940ed5ac98c4a08"""
         params = {
             'action': 'CREATE',
@@ -938,7 +939,8 @@ class SolrCoreAdmin(SolrRequestHandler):
             params.update(instanceDir=name)
         else:
             params.update(instanceDir=instance_dir)
-
+        if data_dir:
+            params.update(dataDir=data_dir)
         if config:
             params.update(config=config)
         if schema:

--- a/pysolr.py
+++ b/pysolr.py
@@ -977,11 +977,14 @@ class SolrCoreAdmin(SolrRequestHandler):
         }
         return self._get_url(params=params)
 
-    def unload(self, core):
+    def unload(self, core, delete_instance_dir=False, delete_index=False, delete_data_dir=False):
         """http://wiki.apache.org/solr/CoreAdmin#head-f5055a885932e2c25096a8856de840b06764d143"""
         params = {
             'action': 'UNLOAD',
             'core': core,
+            'deleteDataDir': delete_data_dir,
+            'deleteInstanceDir': delete_instance_dir,
+            'deleteIndex': delete_index,
         }
         return self._get_url(params=params)
 

--- a/pysolr.py
+++ b/pysolr.py
@@ -173,6 +173,8 @@ def safe_urlencode(params, doseq=0):
 
         if isinstance(v, (list, tuple)):
             new_params.append((k, [force_bytes(i) for i in v]))
+        elif isinstance(v, bool):
+            new_params.append((k, force_bytes(str(v).lower())))
         else:
             new_params.append((k, force_bytes(v)))
 

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from pysolr import SolrCoreAdmin, json
+import re
 
 try:
     import unittest2 as unittest
@@ -12,30 +13,71 @@ except ImportError:
 class SolrCoreAdminTestCase(unittest.TestCase):
     def setUp(self):
         super(SolrCoreAdminTestCase, self).setUp()
-        self.solr_admin = SolrCoreAdmin('http://localhost:8983/solr/admin/cores')
+        self.solr_admin = SolrCoreAdmin('http://localhost:8983')
+        self.solr_admin.create('test_core', instance_dir="collection1")
+
+    def tearDown(self):
+        try:
+            self.solr_admin.unload('test_core')
+        except:
+            # already cleaned up
+            pass
 
     def test_status(self):
         self.assertTrue('name="defaultCoreName"' in self.solr_admin.status())
-        self.assertTrue('<int name="status">' in self.solr_admin.status(core='core0'))
+        self.assertTrue('<int name="status">' in self.solr_admin.status(core='test_core'))
 
     def test_create(self):
-        self.assertTrue('<int name="status">0</int>' in self.solr_admin.create('wheatley'))
+        result = self.solr_admin.create('wheatley', instance_dir="collection1")
+        self.assertTrue('<int name="status">0</int>' in result)
+        self.assertTrue('<str name="core">wheatley</str>' in result)
+        # cleanup
+        self.solr_admin.unload('wheatley')
 
     def test_reload(self):
-        self.assertTrue('<int name="status">0</int>' in self.solr_admin.reload('wheatley'))
+        self.assertTrue('<int name="status">0</int>' in self.solr_admin.reload('test_core'))
 
     def test_rename(self):
-        self.solr_admin.create('wheatley')
-        self.assertTrue('<int name="status">0</int>' in self.solr_admin.rename('wheatley', 'rick'))
+        self.assertTrue('<int name="status">0</int>' in self.solr_admin.rename('test_core', 'rick'))
+        res = self.solr_admin.status()
+        self.assertTrue('<lst name="rick">' in res)
+        self.assertFalse('<lst name="test_core">' in res)
 
+    def _get_uptime(self, core):
+        self.solr_admin.status(core)
+        uptime_pattern = r'<long name="uptime">(?P<uptime>\d+)</long>'
+        res = re.search(
+            uptime_pattern,
+            self.solr_admin.status(core)
+        ).groupdict()
+        if res:
+            return int(res['uptime'])
+        else:
+            None
+    
     def test_swap(self):
-        self.solr_admin.create('wheatley')
-        self.solr_admin.create('rick')
-        self.assertTrue('<int name="status">0</int>' in self.solr_admin.swap('wheatley', 'rick'))
+        self.solr_admin.create('rick', instance_dir="collection1")
+        #TODO find a better way to assert the swap than uptime
+        test_up = self._get_uptime('test_core')
+        rick_up = self._get_uptime('rick')
+        self.assertTrue(test_up > rick_up)
+        self.assertTrue('<int name="status">0</int>' in self.solr_admin.swap('test_core', 'rick'))
+        res = self.solr_admin.status()
+        self.assertTrue('<lst name="rick">' in res)
+        self.assertTrue('<lst name="test_core">' in res)
+        test_up = self._get_uptime('test_core')
+        rick_up = self._get_uptime('rick')
+        self.assertTrue(test_up < rick_up)
+
+        # cleanup
+        self.solr_admin.unload('rick')
 
     def test_unload(self):
-        self.solr_admin.create('wheatley')
+        self.solr_admin.create('wheatley', instance_dir="collection1")
         self.assertTrue('<int name="status">0</int>' in self.solr_admin.unload('wheatley'))
 
     def test_load(self):
         self.assertRaises(NotImplementedError, self.solr_admin.load, 'wheatley')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
SolrCoreAdmin as far as I could tell is completely non functional as it stands currently.  None of the methods work as written and all return the same result as you would get for /solr/admin/cores with no parameters.

This patch makes all SolrCoreAdmin methods functional, adds the missing data_dir parameter to create, and implements tests that actually assert that the SolrCoreAdmin is doing anything at all.
