### PR TITLE
Added support for realtime get

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -608,6 +608,19 @@ class Solr(object):
         return Results(response.get('docs', ()), numFound, **result_kwargs)
 
     def get(self, id=None, ids=None, **kwargs):
+        """
+        Gets latest version of documents, even uncommited ones.
+
+        Requires *either* ``id`` or ``ids``. ``id`` for single document.
+        ``ids`` is a comma separated document ids.
+
+        Optionally accepts ``fl`` - field list.
+
+        Usage::
+
+            solr.get(id='doc_11')
+            solr.get(ids='doc_1,doc_2', fl='id,title')
+        """
         if id is None and ids is None:
             raise ValueError('You must specify "id" or "ids".')
         elif id is not None and ids is not None:

--- a/pysolr.py
+++ b/pysolr.py
@@ -635,7 +635,7 @@ class Solr(object):
         result = self.decoder.decode(response)
 
         if id is not None:
-            docs = filter(None, [result.get('doc')])
+            docs = list(filter(None, [result.get('doc')]))
             numFound = len(docs)
         else:
             response = result.get('response') or {}

--- a/tests/client.py
+++ b/tests/client.py
@@ -332,12 +332,18 @@ class SolrTestCase(unittest.TestCase):
         results = self.solr.get('doc_1')
         self.assertEqual(len(results), 1)
 
-        self.solr.add([{'id': 'doc_6', 'title': 'Realtime doc'}], commit=False)
+        self.solr.add([{'id': 'doc_6', 'title': 'Realtime doc',
+                        'price': 99.99, 'popularity': 1}],
+                      commit=False)
         self.assertEqual(len(self.solr.search('doc')), 3)
         self.assertEqual(len(self.solr.search('realtime')), 0)
 
-        results = self.solr.get(id='doc_6')
+        results = self.solr.get(id='doc_6', fl='id,price')
+        doc = results.docs[0]
         self.assertEqual(len(results), 1)
+        self.assertEqual(len(doc), 2)
+        self.assertEqual(doc['id'], 'doc_6')
+        self.assertAlmostEqual(doc['price'], 99.99)
 
         results = self.solr.get(ids='doc_2,doc_6')
         self.assertEqual(len(results), 2)


### PR DESCRIPTION
See: http://yonik.com/solr/realtime-get/

With this feature it is possible to use Solr as NoSQL database.

This pull-request https://github.com/toastdriven/pysolr/pull/74 doesn't support ids argument. Also Solr supports only id and ids parameters.
