### PR TITLE
Modification to the Solr.add method to allow a generator expression to be used for the docs variable.

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -736,10 +736,8 @@ class Solr(object):
         if commitWithin:
             message.set('commitWithin', commitWithin)
 
-        doc_count = 0
         for doc in docs:
             message.append(self._build_doc(doc, boost=boost))
-            doc_count += 1
 
         # This returns a bytestring. Ugh.
         m = ET.tostring(message, encoding='utf-8')
@@ -747,7 +745,7 @@ class Solr(object):
         m = force_unicode(m)
 
         end_time = time.time()
-        self.log.debug("Built add request of %s docs in %0.2f seconds.", doc_count, end_time - start_time)
+        self.log.debug("Built add request of %s docs in %0.2f seconds.", len(message), end_time - start_time)
         return self._update(m, commit=commit, waitFlush=waitFlush, waitSearcher=waitSearcher)
 
     def delete(self, id=None, q=None, commit=True, waitFlush=None, waitSearcher=None):


### PR DESCRIPTION
Internally the method calls len(docs) to get a count of the number of docs added to Solr (for logging purposes). Generator expressions do not have a **len** method an error is raised if used.
