### PR TITLE
Fixed eval in the _to_python method

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -8,6 +8,7 @@ import re
 import requests
 import time
 import types
+import ast
 
 try:
     # Prefer lxml, if installed.
@@ -512,15 +513,10 @@ class Solr(object):
 
         try:
             # This is slightly gross but it's hard to tell otherwise what the
-            # string's original type might have been. Be careful who you trust.
-            converted_value = eval(value)
-
-            # Try to handle most built-in types.
-            if isinstance(converted_value, (list, tuple, set, dict, int, float, long, complex)):
-                return converted_value
-        except:
-            # If it fails (SyntaxError or its ilk) or we don't trust it,
-            # continue on.
+            # string's original type might have been.
+            return ast.literal_eval(value)
+        except (ValueError, SyntaxError):
+            # If it fails, continue on.
             pass
 
         return value

--- a/tests/client.py
+++ b/tests/client.py
@@ -275,6 +275,7 @@ class SolrTestCase(unittest.TestCase):
         self.assertEqual(self.solr._to_python('hello ☃'), 'hello ☃')
         self.assertEqual(self.solr._to_python(['foo', 'bar']), 'foo')
         self.assertEqual(self.solr._to_python(('foo', 'bar')), 'foo')
+        self.assertEqual(self.solr._to_python('tuple("foo", "bar")'), 'tuple("foo", "bar")')
 
     def test__is_null_value(self):
         self.assertTrue(self.solr._is_null_value(None))


### PR DESCRIPTION
_to_python method is unsafe:

``` python
    from pysolr import Solr
    solr = Solr('http://localhost:8983/solr/collection1')
    solr.add([{'id': 'unsafe', 'name': 'open("/etc/passwd").readlines()'}])
    res = solr.search('id:unsafe')
    print(solr._to_python(res.docs[0]['name']))
```
