### PR TITLE
Added from __future__ import absolute_import

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import absolute_import
 
 import datetime
 import logging


### PR DESCRIPTION
To rid error when there is types.py near pysolr.py.
