### PR TITLE
Solr errors throw TypeError

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -463,9 +463,12 @@ class Solr(object):
                     reason = reason_node.text
 
                 if reason is None:
-                    full_html = ET.tostring(dom_tree)
+                    full_html = ET.tostring(dom_tree, encoding='utf-8')
             except SyntaxError as err:
                 full_html = "%s" % response
+
+        # Some of the code-paths above will return byte-strings instead of Unicode:
+        full_html = force_unicode(full_html)
 
         full_html = full_html.replace('\n', '')
         full_html = full_html.replace('\r', '')


### PR DESCRIPTION
Stuff I have:
- Python 3.3
- Solr 4.5.1
- pysolr==3.1.0
- django-haystack==2.1.0
- lxml==3.2.3

During `rebuild_index` if Solr kicks back an error message I get this traceback:

```
Removing all documents from your index because you said so.
All documents removed.
Indexing 1785 songs
DEBUG 2013-11-10 16:48:07,096 base 21556 139963105810240 Sending message of length 7208 to http://sentry.phazemedia.com/api/9/store/
Traceback (most recent call last):
  File "./manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line
    utility.execute()
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/django/core/management/base.py", line 242, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/haystack/management/commands/rebuild_index.py", line 16, in handle
    call_command('update_index', **options)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/django/core/management/__init__.py", line 159, in call_command
    return klass.execute(*args, **defaults)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/haystack/management/commands/update_index.py", line 195, in handle
    return super(Command, self).handle(*items, **options)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/django/core/management/base.py", line 385, in handle
    label_output = self.handle_label(label, **options)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/haystack/management/commands/update_index.py", line 221, in handle_label
    self.update_backend(label, using)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/haystack/management/commands/update_index.py", line 267, in update_backend
    do_update(backend, index, qs, start, end, total, self.verbosity)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/haystack/management/commands/update_index.py", line 89, in do_update
    backend.update(index, current_qs)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/haystack/backends/solr_backend.py", line 68, in update
    self.conn.add(docs, commit=commit, boost=index.get_field_weights())
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/pysolr.py", line 754, in add
    return self._update(m, commit=commit, waitFlush=waitFlush, waitSearcher=waitSearcher)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/pysolr.py", line 362, in _update
    return self._send_request('post', path, message, {'Content-type': 'text/xml; charset=utf-8'})
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/pysolr.py", line 293, in _send_request
    error_message = self._extract_error(resp)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/pysolr.py", line 372, in _extract_error
    reason, full_html = self._scrape_response(resp.headers, resp.content)
  File "/var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/pysolr.py", line 442, in _scrape_response
    full_html = full_html.replace('\n', '')
TypeError: expected bytes, bytearray or buffer compatible object
```

And here's the culprit variable:

```
> /var/www/_sites/plumradio_20131110163934/env/lib/python3.3/site-packages/pysolr.py(443)_scrape_response()
-> full_html = full_html.replace('\n', '')
(Pdb) full_html
b'<response>\n<lst name="responseHeader"><int name="status">400</int><int name="QTime">1</int></lst><lst name="error"><str name="msg">ERROR: [doc=songs.song.1] unknown field \'django_ct\'</str><int name="code">400</int></lst>\n</response>'
(Pdb)
```

The actual error is a result of me forgetting to copy my schema.xml file (wrist slap), but the resulting TypeError is not graceful.
