### PR TITLE
Try to encode error message in json before attempting to parse it as xml

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -315,9 +315,18 @@ class Solr(object):
                       url, method, log_body[:10], end_time - start_time)
 
         if int(resp.status_code) != 200:
-            error_message = self._extract_error(resp)
-            self.log.error(error_message, extra={'data': {'headers': resp.headers,
-                                                          'response': resp.content}})
+            try:
+                response = json.loads(resp.content)
+                error_message = response['error']['msg']
+            except ValueError:
+                response = resp.content
+                error_message = self._extract_error(resp)
+            self.log.error(error_message, extra={
+                'data': {
+                    'headers': resp.headers,
+                    'response': response,
+                },
+            })
             raise SolrError(error_message)
 
         return force_unicode(resp.content)


### PR DESCRIPTION
This is based on pull request #108 but honours that self._extract_error will fail if it tries to parse a json encoded error return.
