### PR TITLE
Update 'run-tests.py' to invoke unittest2 correctly on Python 2.6

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -41,8 +41,10 @@ def main():
 
     if sys.version_info >= (3, 3):
         cmd = ['python', '-m', 'unittest', 'tests']
-    else:
+    elif sys.version_info >= (2, 7):
         cmd = ['python', '-m', 'unittest2', 'tests']
+    else:
+        cmd = ['unit2', 'discover', '-s', 'tests', '-p', '[a-z]*.py']
 
     try:
         subprocess.check_call(cmd)


### PR DESCRIPTION
Python 2.6 doesn't support `python -m unittest2 ...`, so instead this uses the `unit2` command bundled with `unittest2`.
