### PR TITLE
Support custom Solr handlers

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -322,36 +322,36 @@ class Solr(object):
 
         return force_unicode(resp.content)
 
-    def _select(self, params):
+    def _select(self, params, handler='select'):
         # specify json encoding of results
         params['wt'] = 'json'
         params_encoded = safe_urlencode(params, True)
 
         if len(params_encoded) < 1024:
             # Typical case.
-            path = 'select/?%s' % params_encoded
+            path = '%s/?%s' % (handler, params_encoded)
             return self._send_request('get', path)
         else:
             # Handles very long queries by submitting as a POST.
-            path = 'select/'
+            path = '%s/' % handler
             headers = {
                 'Content-type': 'application/x-www-form-urlencoded; charset=utf-8',
             }
             return self._send_request('post', path, body=params_encoded, headers=headers)
 
-    def _mlt(self, params):
+    def _mlt(self, params, handler='mlt'):
         # specify json encoding of results
         params['wt'] = 'json'
-        path = 'mlt/?%s' % safe_urlencode(params, True)
+        path = '%s/?%s' % (handler, safe_urlencode(params, True))
         return self._send_request('get', path)
 
-    def _suggest_terms(self, params):
+    def _suggest_terms(self, params, handler='terms'):
         # specify json encoding of results
         params['wt'] = 'json'
-        path = 'terms/?%s' % safe_urlencode(params, True)
+        path = '%s/?%s' % (handler, safe_urlencode(params, True))
         return self._send_request('get', path)
 
-    def _update(self, message, clean_ctrl_chars=True, commit=True, waitFlush=None, waitSearcher=None):
+    def _update(self, message, clean_ctrl_chars=True, commit=True, waitFlush=None, waitSearcher=None, handler='update'):
         """
         Posts the given xml message to http://<self.url>/update and
         returns the result.
@@ -361,7 +361,7 @@ class Solr(object):
         these characters would cause Solr to fail to parse the XML. Only pass
         False if you're positive your data is clean.
         """
-        path = 'update/'
+        path = '%s/' % handler
 
         # Per http://wiki.apache.org/solr/UpdateXmlMessages, we can append a
         # ``commit=true`` to the URL and have the commit happen without a
@@ -577,7 +577,7 @@ class Solr(object):
 
     # API Methods ############################################################
 
-    def search(self, q, **kwargs):
+    def search(self, q, handler='select', **kwargs):
         """
         Performs a search and returns the results.
 
@@ -600,7 +600,7 @@ class Solr(object):
         """
         params = {'q': q}
         params.update(kwargs)
-        response = self._select(params)
+        response = self._select(params, handler=handler)
 
         # TODO: make result retrieval lazy and allow custom result objects
         result = self.decoder.decode(response)
@@ -632,7 +632,7 @@ class Solr(object):
         self.log.debug("Found '%s' search results.", numFound)
         return Results(response.get('docs', ()), numFound, **result_kwargs)
 
-    def more_like_this(self, q, mltfl, **kwargs):
+    def more_like_this(self, q, mltfl, handler='mlt', **kwargs):
         """
         Finds and returns results similar to the provided query.
 
@@ -648,7 +648,7 @@ class Solr(object):
             'mlt.fl': mltfl,
         }
         params.update(kwargs)
-        response = self._mlt(params)
+        response = self._mlt(params, handler=handler)
 
         result = self.decoder.decode(response)
 
@@ -661,7 +661,7 @@ class Solr(object):
         self.log.debug("Found '%s' MLT results.", result['response']['numFound'])
         return Results(result['response']['docs'], result['response']['numFound'])
 
-    def suggest_terms(self, fields, prefix, **kwargs):
+    def suggest_terms(self, fields, prefix, handler='terms', **kwargs):
         """
         Accepts a list of field names and a prefix
 
@@ -675,7 +675,7 @@ class Solr(object):
             'terms.prefix': prefix,
         }
         params.update(kwargs)
-        response = self._suggest_terms(params)
+        response = self._suggest_terms(params, handler=handler)
         result = self.decoder.decode(response)
         terms = result.get("terms", {})
         res = {}
@@ -729,7 +729,7 @@ class Solr(object):
 
         return doc_elem
 
-    def add(self, docs, commit=True, boost=None, commitWithin=None, waitFlush=None, waitSearcher=None):
+    def add(self, docs, commit=True, boost=None, commitWithin=None, waitFlush=None, waitSearcher=None, handler='update'):
         """
         Adds or updates documents.
 
@@ -776,9 +776,9 @@ class Solr(object):
 
         end_time = time.time()
         self.log.debug("Built add request of %s docs in %0.2f seconds.", len(message), end_time - start_time)
-        return self._update(m, commit=commit, waitFlush=waitFlush, waitSearcher=waitSearcher)
+        return self._update(m, commit=commit, waitFlush=waitFlush, waitSearcher=waitSearcher, handler=handler)
 
-    def delete(self, id=None, q=None, commit=True, waitFlush=None, waitSearcher=None):
+    def delete(self, id=None, q=None, commit=True, waitFlush=None, waitSearcher=None, handler='update'):
         """
         Deletes documents.
 
@@ -807,9 +807,9 @@ class Solr(object):
         elif q is not None:
             m = '<delete><query>%s</query></delete>' % q
 
-        return self._update(m, commit=commit, waitFlush=waitFlush, waitSearcher=waitSearcher)
+        return self._update(m, commit=commit, waitFlush=waitFlush, waitSearcher=waitSearcher, handler=handler)
 
-    def commit(self, waitFlush=None, waitSearcher=None, expungeDeletes=None):
+    def commit(self, waitFlush=None, waitSearcher=None, expungeDeletes=None, handler='update'):
         """
         Forces Solr to write the index data to disk.
 
@@ -829,9 +829,9 @@ class Solr(object):
         else:
             msg = '<commit />'
 
-        return self._update(msg, waitFlush=waitFlush, waitSearcher=waitSearcher)
+        return self._update(msg, waitFlush=waitFlush, waitSearcher=waitSearcher, handler=handler)
 
-    def optimize(self, waitFlush=None, waitSearcher=None, maxSegments=None):
+    def optimize(self, waitFlush=None, waitSearcher=None, maxSegments=None, handler='update'):
         """
         Tells Solr to streamline the number of segments used, essentially a
         defragmentation operation.
@@ -852,9 +852,9 @@ class Solr(object):
         else:
             msg = '<optimize />'
 
-        return self._update(msg, waitFlush=waitFlush, waitSearcher=waitSearcher)
+        return self._update(msg, waitFlush=waitFlush, waitSearcher=waitSearcher, handler=handler)
 
-    def extract(self, file_obj, extractOnly=True, **kwargs):
+    def extract(self, file_obj, extractOnly=True, handler='update/extract', **kwargs):
         """
         POSTs a file to the Solr ExtractingRequestHandler so rich content can
         be processed using Apache Tika. See the Solr wiki for details:
@@ -891,7 +891,7 @@ class Solr(object):
         try:
             # We'll provide the file using its true name as Tika may use that
             # as a file type hint:
-            resp = self._send_request('post', 'update/extract',
+            resp = self._send_request('post', handler,
                                       body=params,
                                       files={'file': (file_obj.name, file_obj)})
         except (IOError, SolrError) as err:

--- a/tests/client.py
+++ b/tests/client.py
@@ -12,6 +12,12 @@ try:
 except ImportError:
     import unittest
 
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
 try:
     from urllib.parse import unquote_plus
 except ImportError:
@@ -160,6 +166,10 @@ class SolrTestCase(unittest.TestCase):
         # Such is life.
         self.solr.add(self.docs)
 
+        # Mock the _send_request method on the solr instance so that we can
+        # test that custom handlers are called correctly.
+        self.solr._send_request = Mock(wraps=self.solr._send_request)
+
     def tearDown(self):
         self.solr.delete(q='*:*')
         super(SolrTestCase, self).tearDown()
@@ -302,6 +312,9 @@ class SolrTestCase(unittest.TestCase):
     def test_search(self):
         results = self.solr.search('doc')
         self.assertEqual(len(results), 3)
+        # search should default to 'select' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('select/?'))
 
         results = self.solr.search('example')
         self.assertEqual(len(results), 2)
@@ -332,14 +345,38 @@ class SolrTestCase(unittest.TestCase):
         # TODO: Can't get these working in my test setup.
         # self.assertEqual(results.grouped, '')
 
+        # search should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.search('doc', handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
+
     def test_more_like_this(self):
         results = self.solr.more_like_this('id:doc_1', 'text')
         self.assertEqual(len(results), 0)
+        # more_like_this should default to 'mlt' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('mlt/?'))
+
+        # more_like_this should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.more_like_this('id:doc_1', 'text', handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
 
     def test_suggest_terms(self):
         results = self.solr.suggest_terms('title', '')
         self.assertEqual(len(results), 1)
         self.assertEqual(results, {'title': [('doc', 3), ('another', 2), ('example', 2), ('1', 1), ('2', 1), ('boring', 1), ('rock', 1), ('thing', 1)]})
+        # suggest_terms should default to 'mlt' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('terms/?'))
+
+        # suggest_terms should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.suggest_terms('title', '', handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
 
     def test__build_doc(self):
         doc = {
@@ -367,9 +404,18 @@ class SolrTestCase(unittest.TestCase):
                 'title': 'Another example doc',
             },
         ])
+        # add should default to 'update' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('update/?'))
 
         self.assertEqual(len(self.solr.search('doc')), 5)
         self.assertEqual(len(self.solr.search('example')), 3)
+
+        # add should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.add([], handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
 
     def test_add_with_boost(self):
         self.assertEqual(len(self.solr.search('doc')), 3)
@@ -387,6 +433,10 @@ class SolrTestCase(unittest.TestCase):
     def test_delete(self):
         self.assertEqual(len(self.solr.search('doc')), 3)
         self.solr.delete(id='doc_1')
+        # delete should default to 'update' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('update/?'))
+
         self.assertEqual(len(self.solr.search('doc')), 2)
         self.solr.delete(q='price:[0 TO 15]')
         self.assertEqual(len(self.solr.search('doc')), 1)
@@ -400,6 +450,12 @@ class SolrTestCase(unittest.TestCase):
         # Can't have both.
         self.assertRaises(ValueError, self.solr.delete, id='foo', q='bar')
 
+        # delete should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.delete(id='doc_1', handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
+
     def test_commit(self):
         self.assertEqual(len(self.solr.search('doc')), 3)
         self.solr.add([
@@ -410,7 +466,16 @@ class SolrTestCase(unittest.TestCase):
         ], commit=False)
         self.assertEqual(len(self.solr.search('doc')), 3)
         self.solr.commit()
+        # commit should default to 'update' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('update/?'))
         self.assertEqual(len(self.solr.search('doc')), 4)
+
+        # commit should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.commit(handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
 
     def test_optimize(self):
         # Make sure it doesn't blow up. Side effects are hard to measure. :/
@@ -423,7 +488,16 @@ class SolrTestCase(unittest.TestCase):
         ], commit=False)
         self.assertEqual(len(self.solr.search('doc')), 3)
         self.solr.optimize()
+        # optimize should default to 'update' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('update/?'))
         self.assertEqual(len(self.solr.search('doc')), 4)
+
+        # optimize should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.optimize(handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
 
     def test_extract(self):
         fake_f = StringIO("""
@@ -438,6 +512,15 @@ class SolrTestCase(unittest.TestCase):
         """)
         fake_f.name = "test.html"
         extracted = self.solr.extract(fake_f)
+        # extract should default to 'update/extract' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('update/extract'))
+
+        # extract should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.extract(fake_f, handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
 
         # Verify documented response structure:
         self.assertIn('contents', extracted)

--- a/tox.ini
+++ b/tox.ini
@@ -16,11 +16,13 @@ commands = {toxinidir}/run-tests.py
 [testenv:py26]
 deps =
     unittest2
+    mock>=1.0
     {[base]deps}
 
 [testenv:py27]
 deps =
     unittest2
+    mock>=1.0
     {[base]deps}
 
 [testenv:py26-tomcat]


### PR DESCRIPTION
Updates #52 for pysolr 3.2 and adds tests.

Fixes #51, #52.