### PR TITLE
Add support for error response in JSON format. Closes #108, #109

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -394,17 +394,14 @@ class Solr(object):
         full_response = None
 
         if reason is None:
-
-            # if response is in json format
-            full_response = force_unicode(resp.content or '').strip()
-            if full_response.startswith('{'):
-                try:
-                    reason = json.loads(full_response)['error']['msg']
-                except Exception as e:
-                    self.log.error("Failed extracting error message: %r" % e)
-
-            # otherwise we assume it's html
-            else:
+            try:
+                # if response is in json format
+                reason = resp.json()['error']['msg']
+            except KeyError:
+                # if json response has unexpected structure
+                full_response = resp.content
+            except ValueError:
+                # otherwise we assume it's html
                 reason, full_html = self._scrape_response(resp.headers, resp.content)
                 full_response = unescape_html(full_html)
 

--- a/tests/client.py
+++ b/tests/client.py
@@ -229,11 +229,16 @@ class SolrTestCase(unittest.TestCase):
     def test__extract_error(self):
         class RubbishResponse(object):
             def __init__(self, content, headers=None):
+                if isinstance(content, bytes):
+                    content = content.decode('utf-8')
                 self.content = content
                 self.headers = headers
 
                 if self.headers is None:
                     self.headers = {}
+
+            def json(self):
+                return json.loads(self.content)
 
         # Just the reason.
         resp_1 = RubbishResponse("We don't care.", {'reason': 'Something went wrong.'})


### PR DESCRIPTION
Since #60 is probably too big, I propose to support at least JSON responses with this PR. Also, I do not agree how #92, #108 and #109 are trying to address the issue.

Closes #108, #109.

@toastdriven I think #92 should be fixed properly via #60 or something similar for new XML responses.
