### PR TITLE
Update test Solr version to 4.7.0. Use mirrors for faster downloading

### DIFF
--- a/start-test-solr.sh
+++ b/start-test-solr.sh
@@ -2,15 +2,15 @@
 
 set -e
 
-if [ ! -f solr-4.6.0.tgz ]; then
-    curl -O http://archive.apache.org/dist/lucene/solr/4.6.0/solr-4.6.0.tgz
+if [ ! -f solr-4.7.0.tgz ]; then
+    curl -O http://apache.mirrors.spacedump.net/lucene/solr/4.7.0/solr-4.7.0.tgz
 fi
 
-echo "Extracting Solr 4.6.0 to solr4/"
+echo "Extracting Solr 4.7.0 to solr4/"
 rm -rf solr4
 mkdir solr4
-tar -C solr4 -xf solr-4.6.0.tgz --strip-components 2 solr-4.6.0/example
-tar -C solr4 -xf solr-4.6.0.tgz --strip-components 1 solr-4.6.0/dist solr-4.6.0/contrib
+tar -C solr4 -xf solr-4.7.0.tgz --strip-components 2 solr-4.7.0/example
+tar -C solr4 -xf solr-4.7.0.tgz --strip-components 1 solr-4.7.0/dist solr-4.7.0/contrib
 
 echo "Configuring Solr"
 cd solr4


### PR DESCRIPTION
It may be a temporary issue, but when I tried to download today it was 100 KB/s and under, so waiting time was about 30 min (sic!). I recall several other cases when I had to use mirrors which has only the latest version. It is probably smart anyway to test against the latest Solr so we are ready for changes, but it would be great if the script could accept Solr version as a parameter (env var?) so we can automate testing against multiple versions...
