### PR TITLE
check for/handle additional tomcat error responses

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -426,24 +426,33 @@ class Solr(object):
             # Tomcat doesn't produce a valid XML response
             soup = lxml.html.fromstring(response)
             body_node = soup.find('body')
-            p_nodes = body_node.cssselect('p')
+            if body_node:
+                p_nodes = body_node.cssselect('p')
 
-            for p_node in p_nodes:
-                children = p_node.getchildren()
+                for p_node in p_nodes:
+                    children = p_node.getchildren()
 
-                if len(children) >= 2 and 'message' in children[0].text.lower():
-                    reason = children[1].text
+                    if len(children) >= 2 and 'message' in children[0].text.lower():
+                        reason = children[1].text
 
-                if len(children) >= 2 and hasattr(children[0], 'renderContents'):
-                    if 'description' in children[0].renderContents().lower():
-                        if reason is None:
-                            reason = children[1].renderContents()
-                        else:
-                            reason += ", " + children[1].renderContents()
+                    if len(children) >= 2 and hasattr(children[0], 'renderContents'):
+                        if 'description' in children[0].renderContents().lower():
+                            if reason is None:
+                                reason = children[1].renderContents()
+                            else:
+                                reason += ", " + children[1].renderContents()
 
             if reason is None:
                 from lxml.html.clean import clean_html
                 full_html = clean_html(response)
+                # Error response might be provided as json
+                try:
+                    response_data = json.loads(response)
+                except ValueError:
+                    pass
+                else:
+                    if 'error' in response_data:
+                        reason = response_data['error'].get('msg')
         else:
             # Let's assume others do produce a valid XML response
             try:


### PR DESCRIPTION
Fixes #92: "AttributeError: 'NoneType' object has no attribute 'cssselect'"

Based on @MaximusV's comment here:
https://github.com/toastdriven/pysolr/pull/92/files#r7033808

Test for body_node before continuing to try to traverse html.
If reason isn't set by the end of the block, try to extract reason from possible json response that looks like this:

``` json
'{"responseHeader":{"status":400,"QTime":0,"params":{"fl":"* score","sort":"recipient asc","start":"0","q":"(showroom_id:(5) AND user_id:(5))","wt":"json","fq":"django_ct:(sharer.emailshare)","rows":"25"}},"error":{"msg":"sort param field can\'t be found: recipient","code":400}}\n'
```
