### PR TITLE
pysolr.add() - casted commitWithin to string

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -764,7 +764,7 @@ class Solr(object):
         message = ET.Element('add')
 
         if commitWithin:
-            message.set('commitWithin', commitWithin)
+            message.set('commitWithin', str(commitWithin))
 
         for doc in docs:
             message.append(self._build_doc(doc, boost=boost))


### PR DESCRIPTION
The following code throws an Exception:
    solr.add(docs, False, commitWithin=1)

We should allow users to pass in a numerical value to commitWithin.
