### PR TITLE
Fix Python 3.4 error with forcing unicode strings

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -464,6 +464,7 @@ class Solr(object):
             except SyntaxError as err:
                 full_html = "%s" % response
 
+        full_html = force_unicode(full_html)
         full_html = full_html.replace('\n', '')
         full_html = full_html.replace('\r', '')
         full_html = full_html.replace('<br/>', '')


### PR DESCRIPTION
With a specific error about Solr logs, I was getting an:
"expected bytes, bytearray or buffer compatible object" error on the full_html var replace statement

This quick fix removes that problem and works for me.
