### PR TITLE
Support individual field updates introduced with Solr 4.0

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -708,7 +708,7 @@ class Solr(object):
         self.log.debug("Found '%d' Term suggestions results.", sum(len(j) for i, j in res.items()))
         return res
 
-    def _build_doc(self, doc, boost=None):
+    def _build_doc(self, doc, boost=None, fieldUpdates=None):
         doc_elem = ET.Element('doc')
 
         for key, value in doc.items():
@@ -728,6 +728,9 @@ class Solr(object):
 
                 attrs = {'name': key}
 
+                if fieldUpdates and key in fieldUpdates:
+                    attrs['update'] = fieldUpdates[key]
+
                 if boost and key in boost:
                     attrs['boost'] = force_unicode(boost[key])
 
@@ -738,7 +741,7 @@ class Solr(object):
 
         return doc_elem
 
-    def add(self, docs, commit=True, boost=None, commitWithin=None, waitFlush=None, waitSearcher=None):
+    def add(self, docs, commit=True, boost=None, fieldUpdates=None, commitWithin=None, waitFlush=None, waitSearcher=None):
         """
         Adds or updates documents.
 
@@ -776,7 +779,7 @@ class Solr(object):
             message.set('commitWithin', commitWithin)
 
         for doc in docs:
-            message.append(self._build_doc(doc, boost=boost))
+            message.append(self._build_doc(doc, boost=boost, fieldUpdates=fieldUpdates))
 
         # This returns a bytestring. Ugh.
         m = ET.tostring(message, encoding='utf-8')


### PR DESCRIPTION
update = "add" | "set" | "inc"
Explanation: http://wiki.apache.org/solr/UpdateXmlMessages#Optional_attributes_for_.22field.22

Both current and future field update types supported in a generic way.

Example usage:
solrConn.add(docs, fieldUpdates={'myfield1_ss': 'add', 'myfield2_s': 'set', 'myfield3_i': 'inc'})
