### PR TITLE
Request handler

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,21 +115,26 @@ Simply point the URL to the index core:
     solr = pysolr.Solr('http://localhost:8983/solr/core_0/', timeout=10)
 
 
-Custom Request Handler
-~~~~~~~~~~~~~~~~~~~~~~
+Custom Request Handlers
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
     # Setup a Solr instance. The trailing slash is optional.
-    solr = pysolr.Solr('http://localhost:8983/solr/core_0/', query_handler='/autocomplete', use_qt_param=False)
+    solr = pysolr.Solr('http://localhost:8983/solr/core_0/', search_handler='/autocomplete', use_qt_param=False)
 
 
 If ``use_qt_param`` is ``True`` it is essential that the name of the handler is exactly what is configured
-in solrconfig.xml, including the leading slash if any (though with the qt parameter a leading slash is not
-a requirement by SOLR). If ``use_qt_param`` is False (default), the leading and trailing slashes can be
+in ``solrconfig.xml``, including the leading slash if any (though with the ``qt`` parameter a leading slash is not
+a requirement by SOLR). If ``use_qt_param`` is ``False`` (default), the leading and trailing slashes can be
 omitted.
 
-If ``query_handler`` is not specified, pysolr will default to ``/select``.
+If ``search_handler`` is not specified, pysolr will default to ``/select``.
+
+The handlers for MoreLikeThis, Update, Terms etc. all default to the values set in the ``solrconfig.xml`` SOLR ships
+with: ``mlt``, ``update``, ``terms`` etc. The specific methods of pysolr's ``Solr`` class (like ``more_like_this``,
+``suggest_terms`` etc.) allow for a kwarg ``handler`` to override that value. This includes the ``search`` method.
+Setting a handler in ``search`` explicitly overrides the ``search_handler`` setting (if any).
 
 
 LICENSE

--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,34 @@ Basic usage looks like:
     solr = pysolr.SolrCloud(zookeeper, "collection1")
 
 
+Multicore Index
+~~~~~~~~~~~~~~~
+
+Simply point the URL to the index core:
+
+.. code-block:: python
+
+    # Setup a Solr instance. The timeout is optional.
+    solr = pysolr.Solr('http://localhost:8983/solr/core_0/', timeout=10)
+
+
+Custom Request Handler
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    # Setup a Solr instance. The trailing slash is optional.
+    solr = pysolr.Solr('http://localhost:8983/solr/core_0/', query_handler='/autocomplete', use_qt_param=False)
+
+
+If ``use_qt_param`` is ``True`` it is essential that the name of the handler is exactly what is configured
+in solrconfig.xml, including the leading slash if any (though with the qt parameter a leading slash is not
+a requirement by SOLR). If ``use_qt_param`` is False (default), the leading and trailing slashes can be
+omitted.
+
+If ``query_handler`` is not specified, pysolr will default to ``/select``.
+
+
 LICENSE
 =======
 
@@ -134,3 +162,4 @@ Python 2::
 Python 3::
 
     python3 -m unittest tests
+

--- a/get-solr-download-url.py
+++ b/get-solr-download-url.py
@@ -7,11 +7,14 @@ import sys
 
 import requests
 
-# Try to import urljoin from the Python 3 reorganized stdlib first:
+# Try to import urllib from the Python 3 reorganized stdlib first:
 try:
     from urllib.parse import urljoin
 except ImportError:
-    from urlparse import urljoin
+    try:
+        from urlparse.parse import urljoin
+    except ImportError:
+        from urlparse import urljoin
 
 
 if len(sys.argv) != 2:

--- a/pysolr.py
+++ b/pysolr.py
@@ -313,7 +313,7 @@ class Solr(object):
         solr = pysolr.Solr('http://localhost:8983/solr', results_cls=dict)
 
     """
-    def __init__(self, url, decoder=None, timeout=60, results_cls=Results):
+    def __init__(self, url, decoder=None, timeout=60, results_cls=Results, query_handler=None, use_qt_param=False):
         self.decoder = decoder or json.JSONDecoder()
         self.url = url
         self.timeout = timeout
@@ -321,6 +321,8 @@ class Solr(object):
         self.session = requests.Session()
         self.session.stream = False
         self.results_cls = results_cls
+        self.query_handler = query_handler
+        self.use_qt_param = use_qt_param
 
     def __del__(self):
         if hasattr(self, "session"):
@@ -396,36 +398,39 @@ class Solr(object):
 
         return force_unicode(resp.content)
 
-    def _select(self, params, search_handler='select'):
+    def _select(self, params, search_handler=None):
         # specify json encoding of results
         params['wt'] = 'json'
+        custom_handler = search_handler or self.query_handler
+        handler = 'select'
+        if custom_handler:
+            if self.use_qt_param:
+                params['qt'] = custom_handler
+            else:
+                handler = custom_handler
+
         params_encoded = safe_urlencode(params, True)
 
         if len(params_encoded) < 1024:
             # Typical case.
-            path = '%s/?%s' % (search_handler, params_encoded)
+            path = '%s/?%s' % (handler, params_encoded)
             return self._send_request('get', path)
         else:
             # Handles very long queries by submitting as a POST.
-            path = '%s/' % search_handler
+            path = '%s/' % handler
             headers = {
                 'Content-type': 'application/x-www-form-urlencoded; charset=utf-8',
             }
             return self._send_request('post', path, body=params_encoded, headers=headers)
 
-    def _mlt(self, params):
-        # specify json encoding of results
-        params['wt'] = 'json'
-        path = 'mlt/?%s' % safe_urlencode(params, True)
-        return self._send_request('get', path)
+    def _mlt(self, params, handler='mlt'):
+        return self._select(params, handler)
 
-    def _suggest_terms(self, params):
-        # specify json encoding of results
-        params['wt'] = 'json'
-        path = 'terms/?%s' % safe_urlencode(params, True)
-        return self._send_request('get', path)
+    def _suggest_terms(self, params, handler='terms'):
+        return self._select(params, handler)
 
-    def _update(self, message, clean_ctrl_chars=True, commit=True, softCommit=False, waitFlush=None, waitSearcher=None, overwrite=None):
+    def _update(self, message, clean_ctrl_chars=True, commit=True, softCommit=False, waitFlush=None, waitSearcher=None,
+                overwrite=None, handler='update'):
         """
         Posts the given xml message to http://<self.url>/update and
         returns the result.
@@ -435,12 +440,18 @@ class Solr(object):
         these characters would cause Solr to fail to parse the XML. Only pass
         False if you're positive your data is clean.
         """
-        path = 'update/'
 
         # Per http://wiki.apache.org/solr/UpdateXmlMessages, we can append a
         # ``commit=true`` to the URL and have the commit happen without a
         # second request.
         query_vars = []
+
+        path_handler = handler
+        if self.use_qt_param:
+            path_handler = 'select'
+            query_vars.append('qt=%s' % safe_urlencode(handler, True))
+
+        path = '%s/' % path_handler
 
         if commit is not None:
             query_vars.append('commit=%s' % str(bool(commit)).lower())
@@ -676,7 +687,7 @@ class Solr(object):
 
     # API Methods ############################################################
 
-    def search(self, q, search_handler='select', **kwargs):
+    def search(self, q, search_handler=None, **kwargs):
         """
         Performs a search and returns the results.
 
@@ -702,8 +713,21 @@ class Solr(object):
         """
         params = {'q': q}
         params.update(kwargs)
-        response = self._select(params, search_handler)
+        response = self._select(params, search_handler=search_handler)
         decoded = self.decoder.decode(response)
+
+        # TODO: make result retrieval lazy and allow custom result objects
+        result = self.decoder.decode(response)
+        result_kwargs = {}
+
+        if result.get('debug'):
+            result_kwargs['debug'] = result['debug']
+
+        if result.get('highlighting'):
+            result_kwargs['highlighting'] = result['highlighting']
+
+        if result.get('facet_counts'):
+            result_kwargs['facets'] = result['facet_counts']
 
         self.log.debug(
             "Found '%s' search results.",
@@ -712,7 +736,7 @@ class Solr(object):
         )
         return self.results_cls(decoded)
 
-    def more_like_this(self, q, mltfl, **kwargs):
+    def more_like_this(self, q, mltfl, handler='mlt', **kwargs):
         """
         Finds and returns results similar to the provided query.
 
@@ -731,7 +755,7 @@ class Solr(object):
             'mlt.fl': mltfl,
         }
         params.update(kwargs)
-        response = self._mlt(params)
+        response = self._mlt(params, handler=handler)
         decoded = self.decoder.decode(response)
 
         self.log.debug(
@@ -741,7 +765,7 @@ class Solr(object):
         )
         return self.results_cls(decoded)
 
-    def suggest_terms(self, fields, prefix, **kwargs):
+    def suggest_terms(self, fields, prefix, handler='terms', **kwargs):
         """
         Accepts a list of field names and a prefix
 
@@ -755,7 +779,7 @@ class Solr(object):
             'terms.prefix': prefix,
         }
         params.update(kwargs)
-        response = self._suggest_terms(params)
+        response = self._suggest_terms(params, handler=handler)
         result = self.decoder.decode(response)
         terms = result.get("terms", {})
         res = {}
@@ -812,7 +836,8 @@ class Solr(object):
 
         return doc_elem
 
-    def add(self, docs, boost=None, fieldUpdates=None, commit=True, softCommit=False, commitWithin=None, waitFlush=None, waitSearcher=None, overwrite=None):
+    def add(self, docs, boost=None, fieldUpdates=None, commit=True, softCommit=False, commitWithin=None, waitFlush=None,
+            waitSearcher=None, overwrite=None, handler='update'):
         """
         Adds or updates documents.
 
@@ -865,9 +890,10 @@ class Solr(object):
 
         end_time = time.time()
         self.log.debug("Built add request of %s docs in %0.2f seconds.", len(message), end_time - start_time)
-        return self._update(m, commit=commit, softCommit=softCommit, waitFlush=waitFlush, waitSearcher=waitSearcher, overwrite=overwrite)
+        return self._update(m, commit=commit, softCommit=softCommit, waitFlush=waitFlush, waitSearcher=waitSearcher,
+                            overwrite=overwrite, handler=handler)
 
-    def delete(self, id=None, q=None, commit=True, waitFlush=None, waitSearcher=None):
+    def delete(self, id=None, q=None, commit=True, waitFlush=None, waitSearcher=None, handler='update'):
         """
         Deletes documents.
 
@@ -896,9 +922,9 @@ class Solr(object):
         elif q is not None:
             m = '<delete><query>%s</query></delete>' % q
 
-        return self._update(m, commit=commit, waitFlush=waitFlush, waitSearcher=waitSearcher)
+        return self._update(m, commit=commit, waitFlush=waitFlush, waitSearcher=waitSearcher, handler=handler)
 
-    def commit(self, softCommit=False, waitFlush=None, waitSearcher=None, expungeDeletes=None):
+    def commit(self, softCommit=False, waitFlush=None, waitSearcher=None, expungeDeletes=None, handler='update'):
         """
         Forces Solr to write the index data to disk.
 
@@ -920,9 +946,9 @@ class Solr(object):
         else:
             msg = '<commit />'
 
-        return self._update(msg, softCommit=softCommit, waitFlush=waitFlush, waitSearcher=waitSearcher)
+        return self._update(msg, softCommit=softCommit, waitFlush=waitFlush, waitSearcher=waitSearcher, handler=handler)
 
-    def optimize(self,commit=True, waitFlush=None, waitSearcher=None, maxSegments=None):
+    def optimize(self, commit=True, waitFlush=None, waitSearcher=None, maxSegments=None, handler='update'):
         """
         Tells Solr to streamline the number of segments used, essentially a
         defragmentation operation.
@@ -943,9 +969,9 @@ class Solr(object):
         else:
             msg = '<optimize />'
 
-        return self._update(msg, commit=commit, waitFlush=waitFlush, waitSearcher=waitSearcher)
+        return self._update(msg, commit=commit, waitFlush=waitFlush, waitSearcher=waitSearcher, handler=handler)
 
-    def extract(self, file_obj, extractOnly=True, **kwargs):
+    def extract(self, file_obj, extractOnly=True, handler='update/extract', **kwargs):
         """
         POSTs a file to the Solr ExtractingRequestHandler so rich content can
         be processed using Apache Tika. See the Solr wiki for details:
@@ -982,7 +1008,7 @@ class Solr(object):
         try:
             # We'll provide the file using its true name as Tika may use that
             # as a file type hint:
-            resp = self._send_request('post', 'update/extract',
+            resp = self._send_request('post', handler,
                                       body=params,
                                       files={'file': (file_obj.name, file_obj)})
         except (IOError, SolrError) as err:

--- a/pysolr.py
+++ b/pysolr.py
@@ -313,7 +313,7 @@ class Solr(object):
         solr = pysolr.Solr('http://localhost:8983/solr', results_cls=dict)
 
     """
-    def __init__(self, url, decoder=None, timeout=60, results_cls=Results, search_handler=None, use_qt_param=False):
+    def __init__(self, url, decoder=None, timeout=60, results_cls=Results, search_handler='select', use_qt_param=False):
         self.decoder = decoder or json.JSONDecoder()
         self.url = url
         self.timeout = timeout
@@ -398,10 +398,15 @@ class Solr(object):
 
         return force_unicode(resp.content)
 
-    def _select(self, params, search_handler=None):
+    def _select(self, params, handler=None):
+        """
+        :param params:
+        :param handler: defaults to self.search_handler (fallback to 'select')
+        :return:
+        """
         # specify json encoding of results
         params['wt'] = 'json'
-        custom_handler = search_handler or self.search_handler
+        custom_handler = handler or self.search_handler
         handler = 'select'
         if custom_handler:
             if self.use_qt_param:
@@ -713,7 +718,7 @@ class Solr(object):
         """
         params = {'q': q}
         params.update(kwargs)
-        response = self._select(params, search_handler=search_handler)
+        response = self._select(params, handler=search_handler)
         decoded = self.decoder.decode(response)
 
         self.log.debug(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -369,6 +369,9 @@ class SolrTestCase(unittest.TestCase):
     def test_search(self):
         results = self.solr.search('doc')
         self.assertEqual(len(results), 3)
+        # search should default to 'select' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('select/?'))
 
         results = self.solr.search('example')
         self.assertEqual(len(results), 2)
@@ -410,14 +413,38 @@ class SolrTestCase(unittest.TestCase):
         results = self.solr.search(q=misspelled_words, search_handler='spell')
         self.assertNotEqual(results.spellcheck, {})
 
+        # search should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.search('doc', handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
+
     def test_more_like_this(self):
         results = self.solr.more_like_this('id:doc_1', 'text')
         self.assertEqual(len(results), 0)
+        # more_like_this should default to 'mlt' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('mlt/?'))
+
+        # more_like_this should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.more_like_this('id:doc_1', 'text', handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
 
     def test_suggest_terms(self):
         results = self.solr.suggest_terms('title', '')
         self.assertEqual(len(results), 1)
         self.assertEqual(results, {'title': [('doc', 3), ('another', 2), ('example', 2), ('1', 1), ('2', 1), ('boring', 1), ('rock', 1), ('thing', 1)]})
+        # suggest_terms should default to 'mlt' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('terms/?'))
+
+        # suggest_terms should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.suggest_terms('title', '', handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
 
     def test__build_doc(self):
         doc = {
@@ -445,9 +472,18 @@ class SolrTestCase(unittest.TestCase):
                 'title': 'Another example doc',
             },
         ])
+        # add should default to 'update' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('update/?'))
 
         self.assertEqual(len(self.solr.search('doc')), 5)
         self.assertEqual(len(self.solr.search('example')), 3)
+
+        # add should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.add([], handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
 
     def test_add_with_boost(self):
         self.assertEqual(len(self.solr.search('doc')), 3)
@@ -511,6 +547,10 @@ class SolrTestCase(unittest.TestCase):
     def test_delete(self):
         self.assertEqual(len(self.solr.search('doc')), 3)
         self.solr.delete(id='doc_1')
+        # delete should default to 'update' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('update/?'))
+
         self.assertEqual(len(self.solr.search('doc')), 2)
         self.solr.delete(q='price:[0 TO 15]')
         self.assertEqual(len(self.solr.search('doc')), 1)
@@ -524,6 +564,12 @@ class SolrTestCase(unittest.TestCase):
         # Can't have both.
         self.assertRaises(ValueError, self.solr.delete, id='foo', q='bar')
 
+        # delete should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.delete(id='doc_1', handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
+
     def test_commit(self):
         self.assertEqual(len(self.solr.search('doc')), 3)
         self.solr.add([
@@ -534,6 +580,9 @@ class SolrTestCase(unittest.TestCase):
         ], commit=False)
         self.assertEqual(len(self.solr.search('doc')), 3)
         self.solr.commit()
+        # commit should default to 'update' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('update/?'))
         self.assertEqual(len(self.solr.search('doc')), 4)
 
     def test_overwrite(self):
@@ -550,6 +599,12 @@ class SolrTestCase(unittest.TestCase):
         ], overwrite=False)
         self.assertEqual(len(self.solr.search('id:doc_overwrite_1')), 2)
 
+        # commit should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.commit(handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
+
     def test_optimize(self):
         # Make sure it doesn't blow up. Side effects are hard to measure. :/
         self.assertEqual(len(self.solr.search('doc')), 3)
@@ -561,7 +616,16 @@ class SolrTestCase(unittest.TestCase):
         ], commit=False)
         self.assertEqual(len(self.solr.search('doc')), 3)
         self.solr.optimize()
+        # optimize should default to 'update' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('update/?'))
         self.assertEqual(len(self.solr.search('doc')), 4)
+
+        # optimize should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.optimize(handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
 
     def test_extract(self):
         fake_f = StringIO("""
@@ -576,6 +640,15 @@ class SolrTestCase(unittest.TestCase):
         """)
         fake_f.name = "test.html"
         extracted = self.solr.extract(fake_f)
+        # extract should default to 'update/extract' handler
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('update/extract'))
+
+        # extract should support custom handlers
+        with self.assertRaises(SolrError):
+            self.solr.extract(fake_f, handler='fakehandler')
+        args, kwargs = self.solr._send_request.call_args
+        self.assertTrue(args[1].startswith('fakehandler'))
 
         # Verify documented response structure:
         self.assertIn('contents', extracted)


### PR DESCRIPTION
This is a pull request that contains and replaces #112 , addressing #51 and #52 :

Additionally to specifying request handlers at the method level, it allows to specify a `search_handler` as instance variable. Also, a new instance variable `use_qt_param` is available that allows to change how request handlers are specified in the SOLR URL. The default SOLR behavior is to expect the handler as URL path variable (current #112 implementation). The pre 3.6 default behavior (and still available via configuration) specifies the request handler via `qt` parameter in the URL.

This pull request will allow to specify a custom request handler at construction time and thus allow to configure it as data source for Haystack like this:

    HAYSTACK_CONNECTIONS = {
        'default': {
            'ENGINE': 'haystack.backends.solr_backend.SolrEngine',
            'URL': 'http://127.0.0.1:8983/solr/core0'
        },
        'autocomplete': {
            'ENGINE': 'haystack.backends.solr_backend.SolrEngine',
            'URL': 'http://127.0.0.1:8983/solr/core0',
            'KWARGS': {
                'search_handler': '/autocomplete',
                #'use_qt_param': False,  # False by default
            }
        },
    }

Update README to include documentation of custom handlers.

I had to change the import statement in `get-solr-download-url.py` to make the tests run. (Using 3.4 but actually my fix should be for python3 in general.)