### PR TITLE
Add support for nextCursorMark closes #140

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -216,7 +216,7 @@ class SolrError(Exception):
 class Results(object):
     def __init__(self, docs, hits, highlighting=None, facets=None,
                  spellcheck=None, stats=None, qtime=None, debug=None,
-                 grouped=None, nextCursorMark=None):
+                 grouped=None, next_cursor_mark=None):
         self.docs = docs
         self.hits = hits
         self.highlighting = highlighting or {}
@@ -226,7 +226,7 @@ class Results(object):
         self.qtime = qtime
         self.debug = debug or {}
         self.grouped = grouped or {}
-        self.nextCursorMark = nextCursorMark
+        self.next_cursor_mark = next_cursor_mark
 		
     def __len__(self):
         return len(self.docs)

--- a/pysolr.py
+++ b/pysolr.py
@@ -216,7 +216,7 @@ class SolrError(Exception):
 class Results(object):
     def __init__(self, docs, hits, highlighting=None, facets=None,
                  spellcheck=None, stats=None, qtime=None, debug=None,
-                 grouped=None):
+                 grouped=None, nextCursorMark=None):
         self.docs = docs
         self.hits = hits
         self.highlighting = highlighting or {}
@@ -226,7 +226,8 @@ class Results(object):
         self.qtime = qtime
         self.debug = debug or {}
         self.grouped = grouped or {}
-
+        self.nextCursorMark = nextCursorMark
+		
     def __len__(self):
         return len(self.docs)
 
@@ -640,6 +641,9 @@ class Solr(object):
         if result.get('grouped'):
             result_kwargs['grouped'] = result['grouped']
 
+        if result.get('nextCursorMark'):
+            result_kwargs['nextCursorMark'] = result['nextCursorMark']
+			
         response = result.get('response') or {}
         numFound = response.get('numFound', 0)
         self.log.debug("Found '%s' search results.", numFound)

--- a/tests/client.py
+++ b/tests/client.py
@@ -85,7 +85,8 @@ class ResultsTestCase(unittest.TestCase):
             stats='st',
             qtime='0.001',
             debug=True,
-            grouped=['a']
+            grouped=['a'],
+			next_cursor_mark='AoIIP4AAACgwNTc5QjAwMg=='
         )
         self.assertEqual(full_results.docs, [{'id': 1}, {'id': 2}, {'id': 3}])
         self.assertEqual(full_results.hits, 3)
@@ -96,6 +97,7 @@ class ResultsTestCase(unittest.TestCase):
         self.assertEqual(full_results.qtime, '0.001')
         self.assertEqual(full_results.debug, True)
         self.assertEqual(full_results.grouped, ['a'])
+		self.assertEqual(full_results.next_cursor_mark, 'AoIIP4AAACgwNTc5QjAwMg==')
 
     def test_len(self):
         small_results = Results([{'id': 1}, {'id': 2}], 2)


### PR DESCRIPTION
nextCursorMark is required for "deep paging", an important feature since Solr 4.7
see http://solr.pl/en/2014/03/10/solr-4-7-efficient-deep-paging/
