### PR TITLE
Support for nested documents

### DIFF
--- a/tests/client.py
+++ b/tests/client.py
@@ -408,6 +408,15 @@ class SolrTestCase(unittest.TestCase):
         # TODO: Can't get these working in my test setup.
         # self.assertEqual(results.grouped, '')
 
+        # Nested search #1: find parent where child's comment has 'hello'
+        results = self.solr.search("{!parent which=type_s:nested}comment_t:hello")
+        self.assertEqual(len(results), 1)
+        # TODO: for some reason Solr 4.10 returns all parents and non-nested
+        # docs together with matched children when running {!child} query
+        # Nested search #2: find children for parent 'id:nestdoc_1'
+        # results = self.solr.search("{!child of=type_s:nested}id:nestdoc_1")
+        # self.assertEqual(len(results), 2)
+
     def test_more_like_this(self):
         results = self.solr.more_like_this('id:doc_1', 'text')
         self.assertEqual(len(results), 0)

--- a/tests/client.py
+++ b/tests/client.py
@@ -426,6 +426,7 @@ class SolrTestCase(unittest.TestCase):
         # self.assertEqual(len(results), 2)
         # Nested search #3: find child with a child
         results = self.solr.search("{!parent which=type_s:child}comment_t:blah")
+        self.assertEqual(len(results), 1)
 
     def test_more_like_this(self):
         results = self.solr.more_like_this('id:doc_1', 'text')

--- a/tests/client.py
+++ b/tests/client.py
@@ -145,6 +145,42 @@ class SolrTestCase(unittest.TestCase):
                 'price': 1.12,
                 'popularity': 2,
             },
+            # several with nested docs (not using fields that are used in
+            # normal docs so that they don't interfere with their tests)
+            {
+                'id': 'nestdoc_1',
+                'type_s': 'nested',
+                'name_t': 'Nested no. 1',
+                'pages_i': 5,
+                'children': [
+                    {
+                        'id': 'childdoc_1',
+                        'type_s': 'child',
+                        'name_t': 'Child #1',
+                        'comment_t': 'Hello there',
+                    },
+                    {
+                        'id': 'childdoc_2',
+                        'type_s': 'child',
+                        'name_t': 'Child #2',
+                        'comment_t': 'Ehh..',
+                    },
+                ],
+            },
+            {
+                'id': 'nestdoc_2',
+                'type_s': 'nested',
+                'name_t': 'Nested no. 2',
+                'pages_i': 500,
+                'children': [
+                    {
+                        'id': 'childdoc_3',
+                        'type_s': 'child',
+                        'name_t': 'Child of another parent',
+                        'comment_t': 'Yello',
+                    },
+                ],
+            }
         ]
 
         # Clear it.
@@ -470,8 +506,16 @@ class SolrTestCase(unittest.TestCase):
         self.assertEqual(len(self.solr.search('doc')), 3)
         self.solr.delete(id='doc_1')
         self.assertEqual(len(self.solr.search('doc')), 2)
+        self.assertEqual(len(self.solr.search('type_s:nested')), 2)
+        self.assertEqual(len(self.solr.search('type_s:child')), 3)
         self.solr.delete(q='price:[0 TO 15]')
+        self.solr.delete(q='type_s:nested')
+        # one simple doc should remain
+        # parent documents were also deleted but children remain as orphans
         self.assertEqual(len(self.solr.search('doc')), 1)
+        self.assertEqual(len(self.solr.search('type_s:nested')), 0)
+        self.assertEqual(len(self.solr.search('type_s:child')), 3)
+        self.solr.delete(q='type_s:child')
 
         self.assertEqual(len(self.solr.search('*:*')), 1)
         self.solr.delete(q='*:*')


### PR DESCRIPTION
This makes it possible to add nested documents (documents with children) via _Solr.add_. Includes tests as well, however {!child} query seems to be buggy in 4.10 so I left it disabled.

One thing worth discussing is the children key in doc dicts. I simply used "children" but maybe some safer option could be used (like '_children_' or '_childDocuments_' as in Solr's JSON request handler) so that it doesn't accidentally clash with simple fields.