### PR TITLE
Added usefull comments about __init__ to SolrCoreAdmin docstring.

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -1015,6 +1015,13 @@ class SolrCoreAdmin(object):
     """
     Handles core admin operations: see http://wiki.apache.org/solr/CoreAdmin
 
+    Requires to be initializated with the full path to cores admin.
+
+    Usage::
+
+        solr_admin = SolrCoreAdmin('http://localhost:8983/solr/admin/cores')
+        status = solr_admin.status()
+
     Operations offered by Solr are:
        1. STATUS
        2. CREATE


### PR DESCRIPTION
I struggled a while when using this method. It is not consistent with the way Solr class is initialized and may be confusing. I think this comment will help others to initialize this method with the correct url.