### PR TITLE
#199: Deleting fields with value None in Solr.add

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -671,8 +671,6 @@ class Solr(object):
         Criteria for this is based on values that shouldn't be included
         in the Solr ``add`` request at all.
         """
-        if value is None:
-            return True
 
         if IS_PY3:
             # Python 3.X
@@ -818,6 +816,9 @@ class Solr(object):
 
                 if fieldUpdates and key in fieldUpdates:
                     attrs['update'] = fieldUpdates[key]
+
+                if bit is None:
+                    attrs['null'] = 'true'
 
                 if boost and key in boost:
                     attrs['boost'] = force_unicode(boost[key])


### PR DESCRIPTION
When calling add method, if a field has value None, it will be deleted from Solr. This is done using the parameter null="true" in the xml field tag.
