### PR TITLE
Don't append 'Z' to timezone-aware dates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,8 @@ Fix
 
   `__init__` was not actually passing this to the ZooKeeper client
 
+- Don't append 'Z' to timezone-aware dates. Closes #197.  [Andrew Kuchling]
+
 Other
 ~~~~~
 
@@ -956,5 +958,3 @@ v2.0.10 (2010-04-28)
 - Initial import of pysolr. [jkocherhans]
 
 - Initial directory structure. [(no author)]
-
-

--- a/get-solr-download-url.py
+++ b/get-solr-download-url.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from itertools import chain
 import sys
 
 import requests
@@ -25,14 +26,31 @@ solr_version = sys.argv[1]
 tarball = 'solr-{0}.tgz'.format(solr_version)
 dist_path = 'lucene/solr/{0}/{1}'.format(solr_version, tarball)
 
-download_url = urljoin('http://archive.apache.org/dist/', dist_path)
-mirror_response = requests.get("http://www.apache.org/dyn/mirrors/mirrors.cgi/%s?asjson=1" % dist_path)
+download_url = urljoin('https://archive.apache.org/dist/', dist_path)
+mirror_response = requests.get("https://www.apache.org/dyn/mirrors/mirrors.cgi/%s?asjson=1" % dist_path)
 
-if mirror_response.ok:
-    mirror_data = mirror_response.json()
-    download_url = urljoin(mirror_data['preferred'], mirror_data['path_info'])
+if not mirror_response.ok:
+    print('Apache mirror request returned HTTP %d' % mirror_response.status_code, file=sys.stderr)
+    sys.exit(1)
+
+mirror_data = mirror_response.json()
+
+# Since the Apache mirrors are often unreliable and releases may disappear without notice we'll
+# try the preferred mirror, all of the alternates and backups, and fall back to the main Apache
+# archive server:
+for base_url in chain((mirror_data['preferred'], ), mirror_data['http'], mirror_data['backup'],
+                      ('https://archive.apache.org/dist/', )):
+    test_url = urljoin(base_url, mirror_data['path_info'])
+
     # The Apache mirror script's response format has recently changed to exclude the actual file paths:
-    if not download_url.endswith(tarball):
-        download_url = urljoin(download_url, dist_path)
+    if not test_url.endswith(tarball):
+        test_url = urljoin(test_url, dist_path)
+
+    if requests.head(test_url, allow_redirects=True).status_code == 200:
+        download_url = test_url
+        break
+else:
+    print('None of the Apache mirrors have %s' % dist_path, file=sys.stderr)
+    sys.exit(1)
 
 print(download_url)

--- a/pysolr.py
+++ b/pysolr.py
@@ -590,10 +590,18 @@ class Solr(object):
         we send to solr.
         """
         if hasattr(value, 'strftime'):
-            if hasattr(value, 'hour'):
-                value = "%sZ" % value.isoformat()
+            if not hasattr(value, 'tzinfo') or value.tzinfo is None:
+                # For a naive time, just assume it's in UTC
+                tz_suffix = 'Z'
             else:
-                value = "%sT00:00:00Z" % value.isoformat()
+                # There's a timezone, so .isoformat() will include the offset,
+                # and we don't need to append 'Z'.
+                tz_suffix = ''
+
+            if hasattr(value, 'hour'):
+                value = "%s%s" % (value.isoformat(), tz_suffix)
+            else:
+                value = "%sT00:00:00%s" % (value.isoformat(), tz_suffix)
         elif isinstance(value, bool):
             if value:
                 value = 'true'

--- a/pysolr.py
+++ b/pysolr.py
@@ -590,18 +590,13 @@ class Solr(object):
         we send to solr.
         """
         if hasattr(value, 'strftime'):
-            if not hasattr(value, 'tzinfo') or value.tzinfo is None:
-                # For a naive time, just assume it's in UTC
-                tz_suffix = 'Z'
-            else:
-                # There's a timezone, so .isoformat() will include the offset,
-                # and we don't need to append 'Z'.
-                tz_suffix = ''
-
             if hasattr(value, 'hour'):
-                value = "%s%s" % (value.isoformat(), tz_suffix)
+                offset = value.utcoffset()
+                if offset:
+                    value = value - offset
+                value = value.replace(tzinfo=None).isoformat() + 'Z'
             else:
-                value = "%sT00:00:00%s" % (value.isoformat(), tz_suffix)
+                value = "%sT00:00:00Z" % value.isoformat()
         elif isinstance(value, bool):
             if value:
                 value = 'true'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -412,13 +412,13 @@ class SolrTestCase(unittest.TestCase):
         # Check a UTC timestamp
         self.assertEqual(self.solr._from_python(
             datetime.datetime(2013, 1, 18, 0, 30, 28, tzinfo=FakeTimeZone())),
-            '2013-01-18T00:30:28+00:00')
+            '2013-01-18T00:30:28Z')
 
         # Check a US Eastern Standard Time timestamp
         FakeTimeZone.offset = -(5*60)
         self.assertEqual(self.solr._from_python(
             datetime.datetime(2013, 1, 18, 0, 30, 28, tzinfo=FakeTimeZone())),
-            '2013-01-18T00:30:28-05:00')
+            '2013-01-18T05:30:28Z')
 
     def test__to_python(self):
         self.assertEqual(self.solr._to_python('2013-01-18T00:00:00Z'), datetime.datetime(2013, 1, 18))


### PR DESCRIPTION
Here's an alternative fix for issue #197 that's a bit more wordy than pull request #198.  This version of the patch has some logic to figure out the timezone suffix to use, and also adds two tests that exercise the timezone-aware case.

Tests still pass locally.
