### PR TITLE
updated typo in documentation example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ Basic usage looks like:
 
     # For SolrCloud mode, initialize your Solr like this:
 
-    zookeeper = pysolr.Zookeeper("zkhost1:2181,zkhost2:2181,zkhost3:2181")
+    zookeeper = pysolr.ZooKeeper("zkhost1:2181,zkhost2:2181,zkhost3:2181")
     solr = pysolr.SolrCloud(zookeeper, "collection1")
 
 


### PR DESCRIPTION
"Zookeeper" should be "ZooKeeper" on line 104 in README.rst