### PR TITLE
Add ability to declare Solr object with default commit policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 solr*.tgz
 solr-app
 solr
-*.pyc
-logs

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 solr*.tgz
 solr-app
 solr
+*.pyc
+logs

--- a/README.rst
+++ b/README.rst
@@ -200,9 +200,9 @@ Custom Commit Policy
 
     # Setup a Solr instance. The trailing slash is optional.
     # All request to solr will result in a commit
-    solr = pysolr.Solr('http://localhost:8983/solr/core_0/', search_handler='/autocomplete', commit_by_default=True)
+    solr = pysolr.Solr('http://localhost:8983/solr/core_0/', search_handler='/autocomplete', always_commit=True)
 
-``commit_by_default`` signals to the Solr object to either commit or not commit by default for any solr request.
+``always_commit`` signals to the Solr object to either commit or not commit by default for any solr request.
 Be sure to change this to True if you are upgrading from a version where the default policy was alway commit by default.
 
 Functions like ``add`` and ``delete`` also still provide a way to override the default by passing the ``commit`` kwarg.

--- a/README.rst
+++ b/README.rst
@@ -193,6 +193,24 @@ If your Solr servers run off https
 	solr = pysolr.SolrCloud(zookeeper, "collection", verify=path/to/cert.perm)
 
 
+Custom Commit Policy
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    # Setup a Solr instance. The trailing slash is optional.
+    # All request to solr will result in a commit
+    solr = pysolr.Solr('http://localhost:8983/solr/core_0/', search_handler='/autocomplete', commit_by_default=True)
+
+``commit_by_default`` signals to the Solr object to either commit or not commit by default for any solr request.
+Be sure to change this to True if you are upgrading from a version where the default policy was alway commit by default.
+
+Functions like ``add`` and ``delete`` also still provide a way to override the default by passing the ``commit`` kwarg.
+
+It is generally good practice to limit the amount of commits to solr.
+Excessive commits risk opening too many searcher or using too many system resources.
+
+
 
 LICENSE
 =======
@@ -224,4 +242,3 @@ Python 2::
 Python 3::
 
     python3 -m unittest tests
-

--- a/README.rst
+++ b/README.rst
@@ -242,3 +242,4 @@ Python 2::
 Python 3::
 
     python3 -m unittest tests
+

--- a/pysolr.py
+++ b/pysolr.py
@@ -442,11 +442,6 @@ class Solr(object):
     def _suggest_terms(self, params, handler='terms'):
         return self._select(params, handler)
 
-    def _get_commit(self, commit):
-        if commit is None:
-            commit = self.commit_by_default
-        return commit
-
     def _update(self, message, clean_ctrl_chars=True, commit=None, softCommit=False, waitFlush=None, waitSearcher=None,
                 overwrite=None, handler='update'):
         """
@@ -471,7 +466,9 @@ class Solr(object):
 
         path = '%s/' % path_handler
 
-        commit = self._get_commit(commit)
+        if commit is None:
+            commit = self.commit_by_default
+
         if commit:
             query_vars.append('commit=%s' % str(bool(commit)).lower())
         elif softCommit:
@@ -909,7 +906,6 @@ class Solr(object):
         m = force_unicode(m)
 
         end_time = time.time()
-        commit = self._get_commit(commit)
         self.log.debug("Built add request of %s docs in %0.2f seconds.", len(message), end_time - start_time)
         return self._update(m, commit=commit, softCommit=softCommit, waitFlush=waitFlush, waitSearcher=waitSearcher,
                             overwrite=overwrite, handler=handler)
@@ -953,8 +949,6 @@ class Solr(object):
                 raise ValueError('The list of documents to delete was empty.')
         elif q is not None:
             m = '<delete><query>%s</query></delete>' % q
-
-        commit = self._get_commit(commit)
 
         return self._update(m, commit=commit, softCommit=softCommit, waitFlush=waitFlush, waitSearcher=waitSearcher, handler=handler)
 

--- a/pysolr.py
+++ b/pysolr.py
@@ -312,7 +312,7 @@ class Solr(object):
 
     """
 
-    def __init__(self, url, decoder=None, timeout=60, results_cls=Results, search_handler='select', use_qt_param=False, commit_by_default=False,
+    def __init__(self, url, decoder=None, timeout=60, results_cls=Results, search_handler='select', use_qt_param=False, always_commit=False,
                  auth=None, verify=True):
         self.decoder = decoder or json.JSONDecoder()
         self.url = url
@@ -324,7 +324,7 @@ class Solr(object):
         self.use_qt_param = use_qt_param
         self.auth = auth
         self.verify = verify
-        self.commit_by_default = commit_by_default
+        self.always_commit = always_commit
 
     def get_session(self):
         if self.session is None:
@@ -467,7 +467,7 @@ class Solr(object):
         path = '%s/' % path_handler
 
         if commit is None:
-            commit = self.commit_by_default
+            commit = self.always_commit
 
         if commit:
             query_vars.append('commit=%s' % str(bool(commit)).lower())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,6 +6,7 @@ import random
 import unittest
 from io import StringIO
 from xml.etree import ElementTree
+import random
 
 from pysolr import (NESTED_DOC_KEY, Results, Solr, SolrError, clean_xml_string,
                     force_bytes, force_unicode, json, safe_urlencode, sanitize,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -134,8 +134,8 @@ class ResultsTestCase(unittest.TestCase):
 
 
 class SolrTestCaseMixin(object):
-    def get_solr(self, collection, timeout=60, commit_by_default=False):
-        return Solr('http://localhost:8983/solr/%s' % collection, timeout=timeout, commit_by_default=commit_by_default)
+    def get_solr(self, collection, timeout=60, always_commit=False):
+        return Solr('http://localhost:8983/solr/%s' % collection, timeout=timeout, always_commit=always_commit)
 
 
 class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
@@ -237,17 +237,17 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
         # slash handling are caught quickly:
         return self.assertEqual(URL, '%s/%s' % (self.solr.url.replace('/core0', ''), path))
 
-    def get_solr(self, collection, timeout=60, commit_by_default=False):
-        return Solr('http://localhost:8983/solr/%s' % collection, timeout=timeout, commit_by_default=commit_by_default)
+    def get_solr(self, collection, timeout=60, always_commit=False):
+        return Solr('http://localhost:8983/solr/%s' % collection, timeout=timeout, always_commit=always_commit)
 
     def test_init(self):
         self.assertEqual(self.solr.url, 'http://localhost:8983/solr/core0')
         self.assertTrue(isinstance(self.solr.decoder, json.JSONDecoder))
         self.assertEqual(self.solr.timeout, 60)
 
-        custom_solr = self.get_solr("core0", timeout=17, commit_by_default=True)
+        custom_solr = self.get_solr("core0", timeout=17, always_commit=True)
         self.assertEqual(custom_solr.timeout, 17)
-        self.assertEqual(custom_solr.commit_by_default, True)
+        self.assertEqual(custom_solr.always_commit, True)
 
     def test_custom_results_class(self):
         solr = Solr('http://localhost:8983/solr/core0', results_cls=dict)
@@ -923,7 +923,7 @@ class SolrCommitByDefaultTestCase(unittest.TestCase, SolrTestCaseMixin):
 
     def setUp(self):
         super(SolrCommitByDefaultTestCase, self).setUp()
-        self.solr = self.get_solr("core0", commit_by_default=True)
+        self.solr = self.get_solr("core0", always_commit=True)
         self.docs = [
             {
                 'id': 'doc_1',


### PR DESCRIPTION
Since solr has hooks to auto commit after X documents or X seconds, it is best that the `Solr` methods `get`, `delete`, and `_update` do not have a policy of committing by default.

One may already assume this to be false by default since it is good practice to limit commits. But incase users rely on this functionality, there is the ability to declare the default policy in the `Solr` constructor.