### PR TITLE
pysolr.extract() handle spaces and special characters in filenames (with added passing test cases)

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -1034,7 +1034,7 @@ class Solr(object):
             "wt": "json",
         }
         params.update(kwargs)
-        filename = quote(file_obj.name)
+        filename = quote(file_obj.name.encode('utf-8'))
         try:
             # We'll provide the file using its true name as Tika may use that
             # as a file type hint:

--- a/pysolr.py
+++ b/pysolr.py
@@ -33,6 +33,13 @@ except ImportError:
 
 try:
     # Python 3.X
+    from urllib.parse import quote
+except ImportError:
+    # Python 2.X
+    from urllib import quote
+
+try:
+    # Python 3.X
     import html.entities as htmlentities
 except ImportError:
     # Python 2.X
@@ -1027,13 +1034,13 @@ class Solr(object):
             "wt": "json",
         }
         params.update(kwargs)
-
+        filename = quote(file_obj.name)
         try:
             # We'll provide the file using its true name as Tika may use that
             # as a file type hint:
             resp = self._send_request('post', handler,
                                       body=params,
-                                      files={'file': (file_obj.name, file_obj)})
+                                      files={'file': (filename, file_obj)})
         except (IOError, SolrError) as err:
             self.log.error("Failed to extract document metadata: %s", err,
                            exc_info=True)
@@ -1046,10 +1053,10 @@ class Solr(object):
                            exc_info=True)
             raise
 
-        data['contents'] = data.pop(file_obj.name, None)
+        data['contents'] = data.pop(filename, None)
         data['metadata'] = metadata = {}
 
-        raw_metadata = data.pop("%s_metadata" % file_obj.name, None)
+        raw_metadata = data.pop("%s_metadata" % filename, None)
 
         if raw_metadata:
             # The raw format is somewhat annoying: it's a flat list of

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -871,7 +871,7 @@ class SolrTestCase(unittest.TestCase):
                     <body>foobar</body>
             </html>
         """)
-        fake_f.name = "test☃.html"
+        fake_f.name = u"test☃.html"
         extracted = self.solr.extract(fake_f)
         # extract should default to 'update/extract' handler
         args, kwargs = self.solr._send_request.call_args
@@ -891,7 +891,7 @@ class SolrTestCase(unittest.TestCase):
 
         m = extracted['metadata']
 
-        self.assertEqual([quote(fake_f.name)], m['stream_name'])
+        self.assertEqual([quote(fake_f.name.encode('utf-8'))], m['stream_name'])
 
         self.assertIn('haystack-test', m, "HTML metadata should have been extracted!")
         self.assertEqual(['test 1234'], m['haystack-test'])


### PR DESCRIPTION
I created a test case slightly modified from test_extract in test_client.py. See Issue #130 
Thanks to @carina21 for the suggested fix.