### PR TITLE
Issue 251: Iterate through a cursor

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -240,6 +240,9 @@ class Results(object):
     Individual documents can be retrieved either through ``docs`` attribute
     or by iterating over results instance.
 
+    Optional ``next_page_query`` argument is a callable to be invoked when
+    iterating over the documents from the result.
+
     Example::
 
         results = Results({
@@ -267,9 +270,11 @@ class Results(object):
 
     The full response from Solr is provided as the `raw_response` dictionary for use with features which
     change the response format.
+
+
     """
 
-    def __init__(self, decoded):
+    def __init__(self, decoded, next_page_query=None):
         self.raw_response = decoded
 
         # main response part of decoded Solr response
@@ -286,12 +291,14 @@ class Results(object):
         self.qtime = decoded.get('responseHeader', {}).get('QTime', None)
         self.grouped = decoded.get('grouped', {})
         self.nextCursorMark = decoded.get('nextCursorMark', None)
-
-    def __len__(self):
-        return len(self.docs)
+        self._next_page_query = self.nextCursorMark is not None and next_page_query or None
 
     def __iter__(self):
-        return iter(self.docs)
+        result = self
+        while result:
+            for d in result.docs:
+                yield d
+            result = result._next_page_query and result._next_page_query()
 
 
 class Solr(object):
@@ -747,7 +754,15 @@ class Solr(object):
             # cover both cases: there is no response key or value is None
             (decoded.get('response', {}) or {}).get('numFound', 0)
         )
-        return self.results_cls(decoded)
+
+        if "cursorMark" in params and params["cursorMark"] != decoded.get('nextCursorMark',params["cursorMark"]):
+            def next_page_query():
+                nextParams = dict(params)
+                nextParams["cursorMark"]=decoded['nextCursorMark']
+                return self.search(search_handler=search_handler,**nextParams)
+            return self.results_cls(decoded,next_page_query)
+        else:
+            return self.results_cls(decoded)
 
     def more_like_this(self, q, mltfl, handler='mlt', **kwargs):
         """

--- a/pysolr.py
+++ b/pysolr.py
@@ -294,7 +294,7 @@ class Results(object):
         self._next_page_query = self.nextCursorMark is not None and next_page_query or None
 
     def __len__(self):
-        return len(self.docs)
+        return self._next_page_query and self.hits or len(self.docs)
 
     def __iter__(self):
         result = self

--- a/pysolr.py
+++ b/pysolr.py
@@ -293,6 +293,9 @@ class Results(object):
         self.nextCursorMark = decoded.get('nextCursorMark', None)
         self._next_page_query = self.nextCursorMark is not None and next_page_query or None
 
+    def __len__(self):
+        return len(self.docs)
+
     def __iter__(self):
         result = self
         while result:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -262,6 +262,15 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
         assert 'responseHeader' in results
         assert 'response' in results
 
+    def test_cursor_traversal(self):
+        solr = Solr('http://localhost:8983/solr/core0')
+
+        expected = solr.search(q="*:*", rows=len(self.docs)*3, sort="id asc").docs
+        results = solr.search(q='*:*',cursorMark="*",rows=2,sort="id asc")
+        all_docs = [doc for doc in results]
+        self.assertEqual(len(expected), len(all_docs))
+        self.assertEqual(expected, all_docs)
+
     def test__create_full_url_base(self):
         self.assertURLStartsWith(self.solr._create_full_url(path=''),
                                  'core0')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -269,6 +269,7 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
         results = solr.search(q='*:*',cursorMark="*",rows=2,sort="id asc")
         all_docs = [doc for doc in results]
         self.assertEqual(len(expected), len(all_docs))
+        self.assertEqual(len(results), len(all_docs))
         self.assertEqual(expected, all_docs)
 
     def test__create_full_url_base(self):


### PR DESCRIPTION
Iterating over a Result will give all its documents and query for more if and only if there is cursorMark (and sort order) defined in the original query.

One question: What about if someone wants to use a custom Results object AND a cursorMark? I'd be interested in your recommendations on whether or how to handle that.
