### PR TITLE
Add support for named nested documents

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -914,6 +914,21 @@ class Solr(object):
                     child = self._build_doc(bit, boost)
                     doc_elem.append(child)
                     continue
+                elif isinstance(bit, dict):
+                    attrs = {'name': key}
+
+                    if fieldUpdates and key in fieldUpdates:
+                        attrs['update'] = fieldUpdates[key]
+
+                    if boost and key in boost:
+                        attrs['boost'] = force_unicode(boost[key])
+
+                    childfield = ElementTree.Element('field', **attrs)
+
+                    child = self._build_doc(bit, boost)
+                    childfield.append(child)
+                    doc_elem.append(childfield)
+                    continue
 
                 attrs = {"name": key}
 


### PR DESCRIPTION
This patch adds support for named nested documents as supported by solr 8, as documented in the [reference guide](https://www-us.apache.org/dist/lucene/solr/ref-guide/apache-solr-ref-guide-8.1.pdf) (XML example on page 378).

This in turn will support deeply nested documents as it enables the use of the new solr fields \_nest_parent_ and \_nest_path_, which enable new query functions.

It's no longer required to name child documents "_doc" or "\_childDocument\_", they can be any name just like any other tag. The original usage of "_doc" and "\_childDocument\_" remains usable as before.

Usage example:
```
solr.add([
    {
        "id": "doc_1",
        "title": "A test document",
    },
    {
        "id": "doc_2",
        "title": "The Banana: Tasty or Dangerous?",
        "comments": [
            { "id": "child_doc_1", "title": "peel" },
            { "id": "child_doc_2", "title": "seed" },
        ]
    },
])
```