### PR TITLE
run-tests: Avoid unnecessary UTF-8 output

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
-# encoding: utf-8
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, print_function
 
 import faulthandler
 import signal
@@ -20,7 +19,7 @@ def main():
     try:
         unittest.main(module="tests", verbosity=1)
     finally:
-        print("Tests complete; halting Solr servers…")
+        print("Tests complete; halting Solr servers...")
         test_utils.stop_solr()
 
 


### PR DESCRIPTION
Replace the UTF-8 ellipsis with plain ASCII.  Printing it is currently
broken with non-UTF-8 locale, and there is really no technical reason to
add even more complexity for a status message, given that everything
else works just fine.

Fixes #277.