### PR TITLE
Allow empty list for fields with update="set" (fixes #261)

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -949,6 +949,10 @@ class Solr(object):
 
                 doc_elem.append(field)
 
+            if not values and fieldUpdates and fieldUpdates.get(key) == 'set':
+                field = ElementTree.Element("field", name=key, update=fieldUpdates[key])
+                doc_elem.append(field)
+
         return doc_elem
 
     def add(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1100,6 +1100,7 @@ class SolrCommitByDefaultTestCase(unittest.TestCase, SolrTestCaseMixin):
     def setUp(self):
         super(SolrCommitByDefaultTestCase, self).setUp()
         self.solr = self.get_solr("core0", always_commit=True)
+        self.solr.delete(q="*:*", commit=True)
         self.docs = [
             {"id": "doc_1", "title": "Newly added doc"},
             {"id": "doc_2", "title": "Another example doc"},


### PR DESCRIPTION
If I want to remove all the values of the field (say `multivalued_field`) from a doc, I would run:

```python
conn.add({'id': 'myid', 'multivalued_field': []}, fieldUpdates={'multivalued_field': 'set'})
```

But this removes all the field from the doc, because `_build_doc()` strips down empty lists and values:

```python
>>> from xml.etree import ElementTree ; from pysolr import Solr
>>> ElementTree.tostring(Solr(url='')._build_doc({'id': 'myid', 'multivalued_field': []}, fieldUpdates={'multivalued_field': 'set'}))
b'<doc><field name="id">myid</field></doc>'
# This will delete *all* the field
```

For the fields with `update="set"` present, `_build_doc()` should allow empty lists, (like below,) so that Solr would then only delete the values of the specified fields.

```python
>>> from xml.etree import ElementTree ; from pysolr import Solr
>>> ElementTree.tostring(Solr(url='')._build_doc({'id': 'myid', 'multivalued_field': []}, fieldUpdates={'multivalued_field': 'set'}))
b'<doc><field name="id">myid</field><field name="multivalued_field" update="set" /></doc>'
# This will only delete multivalued_field
```