### PR TITLE
Ignore clusterstate.json. Fixes #224.

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -1482,7 +1482,6 @@ class ZooKeeper(object):
     # Constants used by the REST API:
     LIVE_NODES_ZKNODE = "/live_nodes"
     ALIASES = "/aliases.json"
-    CLUSTER_STATE = "/clusterstate.json"
     COLLECTION_STATUS = "/collections"
     COLLECTION_STATE = "/collections/%s/state.json"
     SHARDS = "shards"
@@ -1525,14 +1524,6 @@ class ZooKeeper(object):
                 self.state = state
 
         self.zk.add_listener(connectionListener)
-
-        @self.zk.DataWatch(ZooKeeper.CLUSTER_STATE)
-        def watchClusterState(data, *args, **kwargs):
-            if not data:
-                LOG.warning("No cluster state available: no collections defined?")
-            else:
-                self.collections = json.loads(data.decode("utf-8"))
-                LOG.info("Updated collections: %s", self.collections)
 
         @self.zk.ChildrenWatch(ZooKeeper.LIVE_NODES_ZKNODE)
         def watchLiveNodes(children):


### PR DESCRIPTION
Remove clusterstate.json and listener since the node exists but Solr no longer updates it. This resulted in the collections property being overwritten with an empty state. Tested on Solr 7.7.2. Below is log output during a connection/index/search routine. Without clusterstate being watched the `ZooKeeper` class correctly connects to `live_nodes`, polls `collections`, and polls the collection state to get shards.

```
Updated live nodes: ['172.31.80.126:8983_solr', '172.31.85.226:8983_solr', '172.31.84.9:8983_solr', '172.31.87.69:8983_solr']
Updated aliases: None
Updated collection: ['staging']
Updated collections: {'staging': {'pullReplicas': '0', 'replicationFactor': '2', 'router': {'name': 'compositeId'}, 'maxShardsPerNode': '1', 'autoAddReplicas': 'false', 'nrtReplicas': '2', 'tlogReplicas': '0', 'shards': {'shard1': {'range': '80000000-7fffffff', 'state': 'active', 'replicas': {'core_node3': {'core': 'staging_shard1_replica_n1', 'base_url': 'http://172.31.85.226:8983/solr', 'node_name': '172.31.85.226:8983_solr', 'state': 'recovery_failed', 'type': 'NRT', 'force_set_state': 'false'}, 'core_node4': {'core': 'staging_shard1_replica_n2', 'base_url': 'http://172.31.80.126:8983/solr', 'node_name': '172.31.80.126:8983_solr', 'state': 'active', 'type': 'NRT', 'force_set_state': 'false', 'leader': 'true'}}}}}}
```

I attempted to run the test suite, but it looks like the Solr package referenced is 404 in the test script. Additionally, Solr 4 is unsupported at this point I think.
