### PR TITLE
Fixed: Different JSON and XML behaviour

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -907,13 +907,17 @@ class Solr(object):
         )
         return res
 
-    def _build_doc(self, doc, boost=None, fieldUpdates=None):
+    def _build_json_doc(self, doc):
+        cleaned_doc = {k: v for k, v in doc.items() if not self._is_null_value(v)}
+        return cleaned_doc
+
+    def _build_xml_doc(self, doc, boost=None, fieldUpdates=None):
         doc_elem = ElementTree.Element("doc")
 
         for key, value in doc.items():
             if key == NESTED_DOC_KEY:
                 for child in value:
-                    doc_elem.append(self._build_doc(child, boost, fieldUpdates))
+                    doc_elem.append(self._build_xml_doc(child, boost, fieldUpdates))
                 continue
 
             if key == "boost":
@@ -932,7 +936,7 @@ class Solr(object):
                     continue
 
                 if key == "_doc":
-                    child = self._build_doc(bit, boost)
+                    child = self._build_xml_doc(bit, boost)
                     doc_elem.append(child)
                     continue
 
@@ -1015,7 +1019,8 @@ class Solr(object):
                 # json array of docs
             if isinstance(message, list):
                 # convert to string
-                m = json.dumps(message).encode("utf-8")
+                cleaned_message = [self._build_json_doc(doc) for doc in message]
+                m = json.dumps(cleaned_message).encode("utf-8")
             else:
                 raise ValueError("wrong message type")
         else:
@@ -1025,7 +1030,7 @@ class Solr(object):
                 message.set("commitWithin", commitWithin)
 
             for doc in docs:
-                el = self._build_doc(doc, boost=boost, fieldUpdates=fieldUpdates)
+                el = self._build_xml_doc(doc, boost=boost, fieldUpdates=fieldUpdates)
                 message.append(el)
 
             # This returns a bytestring. Ugh.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -729,8 +729,8 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
 
         doc_json = self.solr._build_json_doc(doc)
         doc_xml = self.solr._build_xml_doc(doc)
-        self.assertTrue("title" not in doc_json)
-        self.assertTrue(doc_xml.find("*[name='title']") is None)
+        self.assertNotIn("title", doc_json)
+        self.assertIsNone(doc_xml.find("*[name='title']"))
 
     def test_add(self):
         self.assertEqual(len(self.solr.search("doc")), 3)


### PR DESCRIPTION
This commit adds a _build_json_doc method that strips keys with empty values from the doc prior to being serialized to JSON. This behaviour matches the behaviour of the XML method. It also uses the same method (_is_null_value) so if this behaviour needs to change in the future it should remain consistent.

It includes a new test to ensure the behaviours of the two methods remain consistent.

Fixes #321