### PR TITLE
Fix SolrCoreAdmin._get_url content-type

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -1307,7 +1307,7 @@ class SolrCoreAdmin(object):
         if params is None:
             params = {}
         if headers is None:
-            headers = {}
+            headers = {'Content-Type': 'application/x-www-form-urlencoded'}
 
         resp = requests.get(url, data=safe_urlencode(params), headers=headers)
         return force_unicode(resp.content)


### PR DESCRIPTION
I've figured out the underlying problem for #318 Unable to create a core. The problem is *requests* does not pass the header `Content-Type: application/x-www-form-urlencoded` when `data` is a string. Since this header is missing, Solr (v8.6) is ignoring the request parameters submitted in the HTTP request body. This effectively causes all request parameters to be ignored from the `SolrCoreAdmin` class. 


---

I ran `run-tests.py` and saw a bunch of warnings but didn't notice any errors. Output:

```
Removing stale working files
Preparing SOLR_HOME for tests at /home/caleb/Downloads/pysolr/solr
Extracting Solr 4.10.4 to /home/caleb/Downloads/pysolr/solr-app
Preparing SOLR_HOME at /home/caleb/Downloads/pysolr/solr/non-cloud for host localhost
Preparing core core0
Preparing core core1
Preparing SOLR_HOME at /home/caleb/Downloads/pysolr/solr/cloud-zk-node for host localhost_zk
Preparing SOLR_HOME at /home/caleb/Downloads/pysolr/solr/cloud-node0 for host localhost_node0
Preparing SOLR_HOME at /home/caleb/Downloads/pysolr/solr/cloud-node1 for host localhost_node1
Preparing core cloud
Starting Solr

Starting server from /home/caleb/Downloads/pysolr/solr/cloud-zk-node on port 8992
Waiting for ZooKeeper to start on 8992... done
Uploading /home/caleb/Downloads/pysolr/solr/cloud-configs/cloud/conf configs to ZooKeeper at localhost:9992

Starting server from /home/caleb/Downloads/pysolr/solr/non-cloud on port 8983

Starting server from /home/caleb/Downloads/pysolr/solr/cloud-node0 on port 8993

Starting server from /home/caleb/Downloads/pysolr/solr/cloud-node1 on port 8994
Waiting for simple-solr to start on 8983.... done
Waiting for cloud-node0 to start on 8993 done
Waiting for cloud-node1 to start on 8994 done
Creating collection core0 on nodes localhost:8993_solr,localhost:8994_solr
Creating collection core1 on nodes localhost:8993_solr,localhost:8994_solr
Solr started
...sssssssssssssssssssssssssssssssssssssssssssssss../usr/lib/python3.6/unittest/suite.py:84: ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60306), raddr=('127.0.0.1', 8983)>
  return self.run(*args, **kwds)
........../usr/lib/python3.6/threading.py:347: ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60330), raddr=('127.0.0.1', 8983)>
  waiters_to_notify = _deque(_islice(all_waiters, n))
/usr/lib/python3.6/threading.py:347: ResourceWarning: unclosed <socket.socket fd=5, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60332), raddr=('127.0.0.1', 8983)>
  waiters_to_notify = _deque(_islice(all_waiters, n))
/usr/lib/python3.6/threading.py:347: ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60334), raddr=('127.0.0.1', 8983)>
  waiters_to_notify = _deque(_islice(all_waiters, n))
......./usr/lib/python3.6/threading.py:226: ResourceWarning: unclosed <socket.socket fd=5, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60340), raddr=('127.0.0.1', 8983)>
  self._release_save = lock._release_save
/usr/lib/python3.6/threading.py:226: ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60342), raddr=('127.0.0.1', 8983)>
  self._release_save = lock._release_save
/usr/lib/python3.6/threading.py:226: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60344), raddr=('127.0.0.1', 8983)>
  self._release_save = lock._release_save
/usr/lib/python3.6/threading.py:226: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60346), raddr=('127.0.0.1', 8983)>
  self._release_save = lock._release_save
/usr/lib/python3.6/threading.py:226: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60348), raddr=('127.0.0.1', 8983)>
  self._release_save = lock._release_save
/usr/lib/python3.6/threading.py:226: ResourceWarning: unclosed <socket.socket fd=11, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60350), raddr=('127.0.0.1', 8983)>
  self._release_save = lock._release_save
....../usr/lib/python3/dist-packages/urllib3/util/retry.py:390: ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60354), raddr=('127.0.0.1', 8983)>
  history = self.history + (RequestHistory(method, url, error, status, redirect_location),)
/usr/lib/python3/dist-packages/urllib3/util/retry.py:390: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60356), raddr=('127.0.0.1', 8983)>
  history = self.history + (RequestHistory(method, url, error, status, redirect_location),)
/usr/lib/python3/dist-packages/urllib3/util/retry.py:390: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60358), raddr=('127.0.0.1', 8983)>
  history = self.history + (RequestHistory(method, url, error, status, redirect_location),)
/usr/lib/python3/dist-packages/urllib3/util/retry.py:390: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60360), raddr=('127.0.0.1', 8983)>
  history = self.history + (RequestHistory(method, url, error, status, redirect_location),)
/usr/lib/python3/dist-packages/urllib3/util/retry.py:390: ResourceWarning: unclosed <socket.socket fd=11, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60362), raddr=('127.0.0.1', 8983)>
  history = self.history + (RequestHistory(method, url, error, status, redirect_location),)
....../usr/lib/python3.6/email/message.py:121: ResourceWarning: unclosed <socket.socket fd=3, family=AddressFamily.AF_INET, 
  self.policy = policy
/usr/lib/python3.6/email/message.py:121: ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60338), raddr=('127.0.0.1', 8983)>
  self.policy = policy
/usr/lib/python3.6/email/message.py:121: ResourceWarning: unclosed <socket.socket fd=5, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60352), raddr=('127.0.0.1', 8983)>
  self.policy = policy
/usr/lib/python3.6/email/message.py:121: ResourceWarning: unclosed <socket.socket fd=12, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60364), raddr=('127.0.0.1', 8983)>
  self.policy = policy
/usr/lib/python3.6/email/message.py:121: ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60368), raddr=('127.0.0.1', 8983)>
  self.policy = policy
/usr/lib/python3.6/email/message.py:121: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60370), raddr=('127.0.0.1', 8983)>
  self.policy = policy
/usr/lib/python3.6/email/message.py:121: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60372), raddr=('127.0.0.1', 8983)>
  self.policy = policy
/usr/lib/python3.6/email/message.py:121: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60374), raddr=('127.0.0.1', 8983)>
  self.policy = policy
/usr/lib/python3.6/email/message.py:121: ResourceWarning: unclosed <socket.socket fd=11, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60376), raddr=('127.0.0.1', 8983)>
  self.policy = policy
..../usr/lib/python3.6/unittest/case.py:605: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60388), raddr=('127.0.0.1', 8983)>
  testMethod()
./usr/lib/python3.6/unittest/case.py:605: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60392), raddr=('127.0.0.1', 8983)>
  testMethod()
./usr/lib/python3/dist-packages/urllib3/response.py:540: ResourceWarning: unclosed <socket.socket fd=3, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60380), raddr=('127.0.0.1', 8983)>
  line = self._fp.fp.readline()
/usr/lib/python3/dist-packages/urllib3/response.py:540: ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60382), raddr=('127.0.0.1', 8983)>
  line = self._fp.fp.readline()
/usr/lib/python3/dist-packages/urllib3/response.py:540: ResourceWarning: unclosed <socket.socket fd=5, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60384), raddr=('127.0.0.1', 8983)>
  line = self._fp.fp.readline()
/usr/lib/python3/dist-packages/urllib3/response.py:540: ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60386), raddr=('127.0.0.1', 8983)>
  line = self._fp.fp.readline()
/usr/lib/python3/dist-packages/urllib3/response.py:540: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60390), raddr=('127.0.0.1', 8983)>
  line = self._fp.fp.readline()
......./home/caleb/.local/lib/python3.6/site-packages/requests/structures.py:60: ResourceWarning: unclosed <socket.socket fd=3, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60396), raddr=('127.0.0.1', 8983)>
  return (casedkey for casedkey, mappedvalue in self._store.values())
/home/caleb/.local/lib/python3.6/site-packages/requests/structures.py:60: ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60398), raddr=('127.0.0.1', 8983)>
  return (casedkey for casedkey, mappedvalue in self._store.values())
/home/caleb/.local/lib/python3.6/site-packages/requests/structures.py:60: ResourceWarning: unclosed <socket.socket fd=5, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60400), raddr=('127.0.0.1', 8983)>
  return (casedkey for casedkey, mappedvalue in self._store.values())
/home/caleb/.local/lib/python3.6/site-packages/requests/structures.py:60: ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60402), raddr=('127.0.0.1', 8983)>
  return (casedkey for casedkey, mappedvalue in self._store.values())
/home/caleb/.local/lib/python3.6/site-packages/requests/structures.py:60: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60404), raddr=('127.0.0.1', 8983)>
  return (casedkey for casedkey, mappedvalue in self._store.values())
/home/caleb/.local/lib/python3.6/site-packages/requests/structures.py:60: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60406), raddr=('127.0.0.1', 8983)>
  return (casedkey for casedkey, mappedvalue in self._store.values())
....../usr/lib/python3.6/xml/etree/ElementTree.py:1314: ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60410), raddr=('127.0.0.1', 8983)>
  parser.feed(text)
/usr/lib/python3.6/xml/etree/ElementTree.py:1314: ResourceWarning: unclosed <socket.socket fd=5, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60412), raddr=('127.0.0.1', 8983)>
  parser.feed(text)
/usr/lib/python3.6/xml/etree/ElementTree.py:1314: ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60414), raddr=('127.0.0.1', 8983)>
  parser.feed(text)
/usr/lib/python3.6/xml/etree/ElementTree.py:1314: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60416), raddr=('127.0.0.1', 8983)>
  parser.feed(text)
/usr/lib/python3.6/xml/etree/ElementTree.py:1314: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 60418), raddr=('127.0.0.1', 8983)>
  parser.feed(text)
..........
Stopping Solr.. stopped

----------------------------------------------------------------------
Ran 110 tests in 31.807s

OK (skipped=47)
Installed SIGUSR1 handler to print stack traces: pkill -USR1 -f run-tests
Tests complete; halting Solr servers…
```