### PR TITLE
Add accepts empty values

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -940,18 +940,26 @@ class Solr(object):
             else:
                 values = (value,)
 
+            use_field_updates = fieldUpdates and key in fieldUpdates
+            if use_field_updates and not values:
+                values = ("",)
             for bit in values:
+
+                attrs = {"name": key}
+
                 if self._is_null_value(bit):
-                    continue
+                    if use_field_updates:
+                        bit = ""
+                        attrs["null"] = "true"
+                    else:
+                        continue
 
                 if key == "_doc":
                     child = self._build_xml_doc(bit, boost)
                     doc_elem.append(child)
                     continue
 
-                attrs = {"name": key}
-
-                if fieldUpdates and key in fieldUpdates:
+                if use_field_updates:
                     attrs["update"] = fieldUpdates[key]
 
                 if boost and key in boost:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -720,6 +720,45 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
         self.assertEqual(children_docs[0].find("*[@name='id']").text, sub_docs[0]["id"])
         self.assertEqual(children_docs[1].find("*[@name='id']").text, sub_docs[1]["id"])
 
+    def test__build_xml_doc_with_empty_values(self):
+        doc = {
+            "id": "doc_1",
+            "title": "",
+            "price": None,
+            "tags": [],
+        }
+        doc_xml = force_unicode(
+            ElementTree.tostring(self.solr._build_xml_doc(doc), encoding="utf-8")
+        )
+        self.assertNotIn('<field name="title" />', doc_xml)
+        self.assertNotIn('<field name="price" />', doc_xml)
+        self.assertNotIn('<field name="tags" />', doc_xml)
+        self.assertIn('<field name="id">doc_1</field>', doc_xml)
+        self.assertEqual(len(doc_xml), 41)
+
+    def test__build_xml_doc_with_empty_values_and_field_updates(self):
+        doc = {
+            "id": "doc_1",
+            "title": "",
+            "price": None,
+            "tags": [],
+        }
+        fieldUpdates = {
+            "title": "set",
+            "tags": "set",
+        }
+        doc_xml = force_unicode(
+            ElementTree.tostring(
+                self.solr._build_xml_doc(doc, fieldUpdates=fieldUpdates),
+                encoding="utf-8",
+            )
+        )
+        self.assertIn('<field name="title" null="true" update="set" />', doc_xml)
+        self.assertNotIn('<field name="price" />', doc_xml)
+        self.assertIn('<field name="tags" null="true" update="set" />', doc_xml)
+        self.assertIn('<field name="id">doc_1</field>', doc_xml)
+        self.assertEqual(len(doc_xml), 134)
+
     def test_build_json_doc_matches_xml(self):
         doc = {
             "id": "doc_1",


### PR DESCRIPTION
When building the Solr document, empty values will not be skipped if
they are also present in the fieldUpdates.  Tests are included.
