### PR TITLE
Escape xml in delete() using ElementTree

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -9,7 +9,6 @@ import random
 import re
 import time
 from xml.etree import ElementTree
-import xml.sax.saxutils
 
 import requests
 from pkg_resources import DistributionNotFound, get_distribution, parse_version
@@ -1120,12 +1119,18 @@ class Solr(object):
             else:
                 doc_id = list(filter(None, id))
             if doc_id:
-                m = "<delete>%s</delete>" % "".join("<id>%s</id>" % xml.sax.saxutils.escape(i) for i in doc_id)
+                et = ElementTree.Element("delete")
+                for one_doc_id in doc_id:
+                    subelem = ElementTree.SubElement(et, 'id')
+                    subelem.text = one_doc_id
+                m = ElementTree.tostring(et)
             else:
                 raise ValueError("The list of documents to delete was empty.")
         elif q is not None:
-            xml_escaped_q = xml.sax.saxutils.escape(q)
-            m = "<delete><query>%s</query></delete>" % xml_escaped_q
+            et = ElementTree.Element("delete")
+            subelem = ElementTree.SubElement(et, 'query')
+            subelem.text = q
+            m = ElementTree.tostring(et)
 
         return self._update(
             m,

--- a/pysolr.py
+++ b/pysolr.py
@@ -9,6 +9,7 @@ import random
 import re
 import time
 from xml.etree import ElementTree
+import xml.sax.saxutils
 
 import requests
 from pkg_resources import DistributionNotFound, get_distribution, parse_version
@@ -1119,11 +1120,12 @@ class Solr(object):
             else:
                 doc_id = list(filter(None, id))
             if doc_id:
-                m = "<delete>%s</delete>" % "".join("<id>%s</id>" % i for i in doc_id)
+                m = "<delete>%s</delete>" % "".join("<id>%s</id>" % xml.sax.saxutils.escape(i) for i in doc_id)
             else:
                 raise ValueError("The list of documents to delete was empty.")
         elif q is not None:
-            m = "<delete><query>%s</query></delete>" % q
+            xml_escaped_q = xml.sax.saxutils.escape(q)
+            m = "<delete><query>%s</query></delete>" % xml_escaped_q
 
         return self._update(
             m,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -909,6 +909,14 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
         self.assertEqual(len(self.solr.search("type_s:grandchild")), 1)
         self.solr.delete(q="price:[0 TO 15]")
         self.solr.delete(q="type_s:parent", commit=True)
+
+        # Test a query that would need to be quoted when using the XML API.
+        # These will delete too much when using v3.9.0 or earlier.
+        self.solr.delete(q='id:*</query><query> id:999 AND id:9999')
+        self.solr.delete(id='doc_4</id><id>doc_3</id><id>doc_2</id><id>doc_1',commit=True)
+        # Ids with a "<" character will give an error using v3.9.0 or earlier
+        self.solr.delete(id='cats<dogs')
+
         # one simple doc should remain
         # parent documents were also deleted but children remain as orphans
         self.assertEqual(len(self.solr.search("doc")), 1)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -911,11 +911,11 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
         self.solr.delete(q="type_s:parent", commit=True)
 
         # Test a query that would need to be quoted when using the XML API.
-        # These will delete too much when using v3.9.0 or earlier.
-        self.solr.delete(q='id:*</query><query> id:999 AND id:9999')
-        self.solr.delete(id='doc_4</id><id>doc_3</id><id>doc_2</id><id>doc_1',commit=True)
         # Ids with a "<" character will give an error using v3.9.0 or earlier
         self.solr.delete(id='cats<dogs')
+        # These will delete too much when using v3.9.0 or earlier.
+        self.solr.delete(q='id:*</query><query> id:999 AND id:9999')
+        self.solr.delete(id='doc_4</id><id>doc_3', commit=True)
 
         # one simple doc should remain
         # parent documents were also deleted but children remain as orphans


### PR DESCRIPTION
A different approach to [#356] using ElementTree as suggested in a comment.


Type pysolr .delete() method was not escaping special characters like <, >, and & in the XML it was generating.

In particular attempts to delete documents by IDs like this: 

        self.solr.delete(id='cats<dogs')

would give error messages, and attempts to delete documents like this:

        self.solr.delete(q='id:*</query><query> id:999 AND id:9999')

could delete more than you would have expected.   This pull request (with test cases) escapes the IDs and Lucene Query Expressions in the XML generation step.