### PR TITLE
Slight expansion of the cursor example in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ Basic usage looks like:
     })
 
     # Traverse a cursor using its iterator:
-    for doc in solr.search('*:*',fl='id',cursorMark='*'):
+    for doc in solr.search('*:*',fl='id',cursorMark='*', sort='id desc'):
         print(doc['id'])
 
     # You can also perform More Like This searches, if your Solr is configured

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,8 @@ Basic usage looks like:
         'hl.fragsize': 10,
     })
 
-    # Traverse a cursor using its iterator:
+    # Traverse a cursor using its iterator.
+    # In this case, a tie breaker by a uniqueKey must be given in the sort parameter.
     for doc in solr.search('*:*',fl='id',cursorMark='*', sort='id desc'):
         print(doc['id'])
 


### PR DESCRIPTION
I justed executed the example given in the README and ran into the issue that a cursor needs a tie breaker (at least in Solr 7.7). Hence, expanded the example.

Cheers,

Adrian