### PR TITLE
Simplify using flake8-simplify

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
     - repo: https://github.com/PyCQA/isort
-      rev: 5.10.1
+      rev: 5.12.0
       hooks:
           - id: isort
     - repo: https://github.com/psf/black
-      rev: 22.3.0
+      rev: 23.3.0
       hooks:
           - id: black
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.2.0
+      rev: v4.4.0
       hooks:
           - id: check-added-large-files
             args: ["--maxkb=128"]
@@ -33,7 +33,7 @@ repos:
             args: ["--autofix", "--no-sort-keys", "--indent=4"]
           - id: trailing-whitespace
     - repo: https://github.com/PyCQA/flake8
-      rev: 4.0.1
+      rev: 6.0.0
       hooks:
           - id: flake8
             additional_dependencies:

--- a/pysolr.py
+++ b/pysolr.py
@@ -708,10 +708,7 @@ class Solr(object):
             else:
                 value = "%sT00:00:00Z" % value.isoformat()
         elif isinstance(value, bool):
-            if value:
-                value = "true"
-            else:
-                value = "false"
+            value = "true" if value else "false"
         else:
             if IS_PY3:
                 # Python 3.X
@@ -986,10 +983,7 @@ class Solr(object):
 
             # To avoid multiple code-paths we'd like to treat all of our values
             # as iterables:
-            if isinstance(value, (list, tuple, set)):
-                values = value
-            else:
-                values = (value,)
+            values = value if isinstance(value, (list, tuple, set)) else (value,)
 
             use_field_updates = fieldUpdates and key in fieldUpdates
             if use_field_updates and not values:
@@ -1633,13 +1627,10 @@ class ZooKeeper(object):
             raise SolrError("Unknown collection: %s" % collname)
         collection = self.collections[collname]
         shards = collection[ZooKeeper.SHARDS]
-        for shardname in shards.keys():
-            shard = shards[shardname]
+        for shard in shards.values():
             if shard[ZooKeeper.STATE] == ZooKeeper.ACTIVE:
                 replicas = shard[ZooKeeper.REPLICAS]
-                for replicaname in replicas.keys():
-                    replica = replicas[replicaname]
-
+                for replica in replicas.values():
                     if replica[ZooKeeper.STATE] == ZooKeeper.ACTIVE:
                         if not only_leader or (
                             replica.get(ZooKeeper.LEADER, None) == ZooKeeper.TRUE

--- a/pysolr.py
+++ b/pysolr.py
@@ -989,7 +989,6 @@ class Solr(object):
             if use_field_updates and not values:
                 values = ("",)
             for bit in values:
-
                 attrs = {"name": key}
 
                 if self._is_null_value(bit):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -839,8 +839,8 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
             # TODO: change this to use assertSetEqual:
             self.assertTrue(
                 all(
-                    updatedDoc[k] == originalDoc[k]
-                    for k in updatedDoc.keys()
+                    v == originalDoc[k]
+                    for k, v in updatedDoc.items()
                     if k not in ["_version_", "popularity"]
                 )
             )
@@ -862,8 +862,8 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
             # TODO: change this to use assertSetEqual:
             self.assertTrue(
                 all(
-                    updatedDoc[k] == originalDoc[k]
-                    for k in updatedDoc.keys()
+                    v == originalDoc[k]
+                    for k, v in updatedDoc.items()
                     if k not in ["_version_", "popularity"]
                 )
             )
@@ -902,8 +902,8 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
             # TODO: change this to use assertSetEqual:
             self.assertTrue(
                 all(
-                    updatedDoc[k] == originalDoc[k]
-                    for k in updatedDoc.keys()
+                    v == originalDoc[k]
+                    for k, v in updatedDoc.items()
                     if k not in ["_version_", "word_ss"]
                 )
             )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -833,7 +833,7 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
 
         updatedDocs = self.solr.search("doc")
         self.assertEqual(len(updatedDocs), 3)
-        for (originalDoc, updatedDoc) in zip(originalDocs, updatedDocs):
+        for originalDoc, updatedDoc in zip(originalDocs, updatedDocs):
             self.assertEqual(len(updatedDoc.keys()), len(originalDoc.keys()))
             self.assertEqual(updatedDoc["popularity"], originalDoc["popularity"] + 5)
             # TODO: change this to use assertSetEqual:
@@ -856,7 +856,7 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
 
         updatedDocs = self.solr.search("doc")
         self.assertEqual(len(updatedDocs), 3)
-        for (originalDoc, updatedDoc) in zip(originalDocs, updatedDocs):
+        for originalDoc, updatedDoc in zip(originalDocs, updatedDocs):
             self.assertEqual(len(updatedDoc.keys()), len(originalDoc.keys()))
             self.assertEqual(updatedDoc["popularity"], updated_popularity)
             # TODO: change this to use assertSetEqual:
@@ -894,7 +894,7 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
 
         updatedDocs = self.solr.search("multivalued")
         self.assertEqual(len(updatedDocs), 2)
-        for (originalDoc, updatedDoc) in zip(originalDocs, updatedDocs):
+        for originalDoc, updatedDoc in zip(originalDocs, updatedDocs):
             self.assertEqual(len(updatedDoc.keys()), len(originalDoc.keys()))
             self.assertEqual(
                 updatedDoc["word_ss"], originalDoc["word_ss"] + ["epsilon", "gamma"]


### PR DESCRIPTION
% `ruff --select=SIM108,SIM118 --fix .`
```
Found 7 errors (7 fixed, 0 remaining).
```
% `ruff rule SIM108`
# if-else-block-instead-of-if-exp (SIM108)

Derived from the **flake8-simplify** linter.

Autofix is sometimes available.

Message formats:
* Use ternary operator `{contents}` instead of `if`-`else`-block

% `ruff rule SIM118`
# in-dict-keys (SIM118)

Derived from the **flake8-simplify** linter.

Autofix is always available.

Message formats:
* Use `{key} in {dict}` instead of `{key} in {dict}.keys()`