### PR TITLE
Replace flake8 and isort with ruff

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,11 +1,20 @@
-name: tox
+name: ruff_and_tox
 on:
   push:
     branches: [master]
   pull_request:
     branches: [master]
 jobs:
+  ruff:  # https://beta.ruff.rs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user "codespell[toml]" ruff
+    - run: codespell
+    - run: ruff --format=github .
+
   tox:
+    needs: ruff
     strategy:
       fail-fast: false
       max-parallel: 6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,4 @@
 repos:
-    - repo: https://github.com/PyCQA/isort
-      rev: 5.12.0
-      hooks:
-          - id: isort
-    - repo: https://github.com/psf/black
-      rev: 23.3.0
-      hooks:
-          - id: black
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.4.0
       hooks:
@@ -20,6 +12,7 @@ repos:
           - id: check-json
           - id: check-merge-conflict
           - id: check-symlinks
+          - id: check-toml
           - id: check-xml
           - id: check-yaml
           - id: debug-statements
@@ -32,12 +25,30 @@ repos:
           - id: pretty-format-json
             args: ["--autofix", "--no-sort-keys", "--indent=4"]
           - id: trailing-whitespace
-    - repo: https://github.com/PyCQA/flake8
-      rev: 6.0.0
+
+    - repo: https://github.com/codespell-project/codespell
+      rev: v2.2.4
       hooks:
-          - id: flake8
+          - id: codespell
             additional_dependencies:
-                - flake8-assertive
-                - flake8-builtins
-                - flake8-comprehensions
-                - flake8-logging-format
+                - tomli
+
+    - repo: https://github.com/charliermarsh/ruff-pre-commit
+      rev: v0.0.263
+      hooks:
+          - id: ruff
+
+    - repo: https://github.com/psf/black
+      rev: 23.3.0
+      hooks:
+          - id: black
+
+    - repo: https://github.com/tox-dev/pyproject-fmt
+      rev: 0.10.0
+      hooks:
+          - id: pyproject-fmt
+
+    - repo: https://github.com/abravalheri/validate-pyproject
+      rev: v0.12.2
+      hooks:
+          - id: validate-pyproject

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -274,7 +274,7 @@ v3.4.0 (2016-02-02)
   This change uses 'non-mutable' message that is complemented
   with extracted data that using string formatting option supplied
   by Python logging. Thanks to this, Sentry and other solutions
-  can perform better grouping of loging messages (by status code).
+  can perform better grouping of logging messages (by status code).
 
   This is approach that is already used in handling other errors.
 
@@ -613,7 +613,7 @@ v3.0.6 (2013-04-13)
 
 - Merge pull request #71 from mjumbewu/master. [Daniel Lindsley]
 
-  Trailing slash in the base URL will break reqeusts
+  Trailing slash in the base URL will break requests
 
 - Make sure trailing and leading slashes do not collide. [Mjumbe Wawatu
   Ukweli]

--- a/Pipfile
+++ b/Pipfile
@@ -4,17 +4,8 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-bandit = "*"
-black = "==19.3b0"
 coverage = "*"
-flake8 = "*"
-flake8-assertive = "*"
-flake8-bugbear = "*"
-flake8-builtins = "*"
-flake8-comprehensions = "*"
-flake8-eradicate = "*"
-flake8-logging-format = "*"
-isort = "*"
+ruff = "*"
 
 [packages]
 requests = "*"

--- a/README.rst
+++ b/README.rst
@@ -174,7 +174,7 @@ Custom Authentication
 
 .. code-block:: python
 
-    # Setup a Solr instance in a kerborized enviornment
+    # Setup a Solr instance in a kerborized environment
     from requests_kerberos import HTTPKerberosAuth, OPTIONAL
     kerberos_auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL, sanitize_mutual_error_response=False)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,88 @@
+[tool.codespell]
+ignore-words-list = "dekstop,nwe,yello"
+skip="./.*"
+
+[tool.ruff]
+select = [
+  "A",      # flake8-builtins
+  "B",      # flake8-bugbear
+  "BLE",    # flake8-blind-except
+  "C4",     # flake8-comprehensions
+  "C90",    # McCabe cyclomatic complexity
+  "E",      # pycodestyle
+  "ERA",    # eradicate
+  "EXE",    # flake8-executable
+  "F",      # Pyflakes
+  "G",      # flake8-logging-format
+  "I",      # isort
+  "ICN",    # flake8-import-conventions
+  "INP",    # flake8-no-pep420
+  "INT",    # flake8-gettext
+  "ISC",    # flake8-implicit-str-concat
+  "N",      # pep8-naming
+  "PGH",    # pygrep-hooks
+  "PIE",    # flake8-pie
+  "PL",     # Pylint
+  "PT",     # flake8-pytest-style
+  "PTH",    # flake8-use-pathlib
+  "PYI",    # flake8-pyi
+  "RET",    # flake8-return
+  "RSE",    # flake8-raise
+  "RUF",    # Ruff-specific rules
+  "S",      # flake8-bandit
+  "T10",    # flake8-debugger
+  "TCH",    # flake8-type-checking
+  "TID",    # flake8-tidy-imports
+  "W",      # pycodestyle
+  "YTT",    # flake8-2020
+  # "ANN",  # flake8-annotations
+  # "ARG",  # flake8-unused-arguments
+  # "COM",  # flake8-commas
+  # "D",    # pydocstyle
+  # "DJ",   # flake8-django
+  # "DTZ",  # flake8-datetimez
+  # "EM",   # flake8-errmsg
+  # "FBT",  # flake8-boolean-trap
+  # "NPY",  # NumPy-specific rules
+  # "PD",   # pandas-vet
+  # "Q",    # flake8-quotes
+  # "SIM",  # flake8-simplify
+  # "SLF",  # flake8-self
+  # "T20",  # flake8-print
+  # "TRY",  # tryceratops
+  # "UP",   # pyupgrade
+]
+ignore = [
+  "B018",
+  "B026",
+  "B904",
+  "N802",
+  "N803",
+  "N806",
+  "PGH004",
+  "PLR5501",
+  "PLW2901",
+  "PT009",
+  "PTH123",
+  "RET505",
+  "RET506",
+  "RUF100",
+  "S113",
+  "S311",
+  "S314",
+  "S603",
+]
+target-version = "py37"
+
+[tool.ruff.mccabe]
+max-complexity = 16
+
+[tool.ruff.pylint]
+allow-magic-value-types = ["int", "str"]
+max-args = 12
+max-branches = 20
+max-returns = 7
+max-statements = 54
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["S101"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,19 +1,2 @@
 [wheel]
 universal = 1
-
-[flake8]
-exclude = .venv,node_modules
-max-line-length = 88
-enable-extensions = G
-
-[isort]
-default_section = THIRDPARTY
-ensure_newline_before_comments = True
-force_grid_wrap = 0
-include_trailing_comma = True
-known_first_party = pysolr
-line_length = 88
-multi_line_output = 3
-not_skip = __init__.py
-skip = .venv
-use_parentheses = True


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

The ruff Action uses minimal steps to run in ~5 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)

Running the complete test matrix on GitHub Actions takes a lot of time and CPU.  Given that the `ruff` linting job is so fast (~5 seconds) let's ensure that linting passes ___before___ the complete test matrix is run.  This will cost a few seconds on each run but could save a lot of time and contention for PRs that should be cleaned up before they are fully tested.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds
![image](https://user-images.githubusercontent.com/3709715/234560204-337aed59-85c6-48c2-9b20-53869beeb633.png)
