### PR TITLE
Configure GitHub actions to publish packages

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,7 +1,6 @@
 name: "PyPI releases"
 
-# FIXME: restrict this to releases after testing
-on: [push, release]
+on: release
 
 jobs:
     build_sdist:
@@ -19,8 +18,7 @@ jobs:
 
     pypi-publish:
         name: Upload release to PyPI
-        # FIXME: restrict this after testing
-        # if: github.event_name == 'release' && github.event.action == 'published'
+        if: github.event_name == 'release' && github.event.action == 'published'
         needs:
             - build_sdist
         runs-on: ubuntu-latest

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,6 +1,7 @@
 name: "PyPI releases"
 
-on: release
+# FIXME: restrict this to releases after testing
+on: [push, release]
 
 jobs:
     build_sdist:
@@ -18,7 +19,8 @@ jobs:
 
     pypi-publish:
         name: Upload release to PyPI
-        if: github.event_name == 'release' && github.event.action == 'published'
+        # FIXME: restrict this after testing
+        # if: github.event_name == 'release' && github.event.action == 'published'
         needs:
             - build_sdist
         runs-on: ubuntu-latest

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,38 @@
+name: "PyPI releases"
+
+on: release
+
+jobs:
+    build_sdist:
+        name: Build Python source distribution
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Build sdist
+              run: pipx run build --sdist
+
+            - uses: actions/upload-artifact@v3
+              with:
+                  path: dist/*.tar.gz
+
+    pypi-publish:
+        name: Upload release to PyPI
+        if: github.event_name == 'release' && github.event.action == 'published'
+        needs:
+            - build_sdist
+        runs-on: ubuntu-latest
+        environment:
+            name: pypi
+            url: https://pypi.org/p/pysolr
+        permissions:
+            id-token: write
+        steps:
+            - uses: actions/download-artifact@v3
+              with:
+                  # unpacks default artifact into dist/
+                  # if `name: artifact` is omitted, the action will create extra parent dir
+                  name: artifact
+                  path: dist
+            - name: Publish package distributions to PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This is a first pass enabling the PyPI trusted publisher workflow