### PR TITLE
fix commitWithin for JSON updates w/o `boost`

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -502,6 +502,7 @@ class Solr(object):
         clean_ctrl_chars=True,
         commit=None,
         softCommit=False,
+        commitWithin=None,
         waitFlush=None,
         waitSearcher=None,
         overwrite=None,
@@ -540,6 +541,8 @@ class Solr(object):
             query_vars.append("commit=%s" % str(bool(commit)).lower())
         elif softCommit:
             query_vars.append("softCommit=%s" % str(bool(softCommit)).lower())
+        elif commitWithin is not None:
+            query_vars.append("commitWithin=%s" % str(int(commitWithin)))
 
         if waitFlush is not None:
             query_vars.append("waitFlush=%s" % str(bool(waitFlush)).lower())
@@ -909,7 +912,7 @@ class Solr(object):
         )
         return res
 
-    def _build_docs(self, docs, boost=None, fieldUpdates=None, commitWithin=None):
+    def _build_docs(self, docs, boost=None, fieldUpdates=None):
         # if no boost needed use json multidocument api
         #   The JSON API skips the XML conversion and speedup load from 15 to 20 times.
         #   CPU Usage is drastically lower.
@@ -933,9 +936,6 @@ class Solr(object):
         else:
             solrapi = "XML"
             message = ElementTree.Element("add")
-
-            if commitWithin:
-                message.set("commitWithin", commitWithin)
 
             for doc in docs:
                 el = self._build_xml_doc(doc, boost=boost, fieldUpdates=fieldUpdates)
@@ -1066,7 +1066,9 @@ class Solr(object):
         start_time = time.time()
         self.log.debug("Starting to build add request...")
         solrapi, m, len_message = self._build_docs(
-            docs, boost, fieldUpdates, commitWithin
+            docs,
+            boost,
+            fieldUpdates,
         )
         end_time = time.time()
         self.log.debug(
@@ -1078,6 +1080,7 @@ class Solr(object):
             m,
             commit=commit,
             softCommit=softCommit,
+            commitWithin=commitWithin,
             waitFlush=waitFlush,
             waitSearcher=waitSearcher,
             overwrite=overwrite,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 
 import datetime
 import random
+import time
 import unittest
 from io import StringIO
 from xml.etree import ElementTree
@@ -822,6 +823,22 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
         res = self.solr.search("doc")
         self.assertEqual(len(res), 5)
         self.assertEqual("doc_6", res.docs[0]["id"])
+
+    def test_add_with_commit_within(self):
+        self.assertEqual(len(self.solr.search("commitWithin")), 0)
+
+        commit_within_ms = 50
+        self.solr.add(
+            [
+                {"id": "doc_6", "title": "commitWithin test"},
+            ],
+            commitWithin=commit_within_ms,
+        )
+        # we should not see the doc immediately
+        self.assertEqual(len(self.solr.search("commitWithin")), 0)
+        # but we should see it after commitWithin period (+ small grace period)
+        time.sleep((commit_within_ms / 1000.0) + 0.01)
+        self.assertEqual(len(self.solr.search("commitWithin")), 1)
 
     def test_field_update_inc(self):
         originalDocs = self.solr.search("doc")


### PR DESCRIPTION
 - add `commitWithin` to the `Solr._update` methodm and modify that method to include `commitWithin` as a query parameter if it is provided
 - remove the code that added `commitWithin` inside the `add` XML messages, so it's handled the same for botth XML and JSON
 - add a test case for `commitWithin`, which wasn't tested previously
 - this fixes a regression in 3.9.0 that resulted in `add` calls without a `boost` or `fieldUpdates` value no longer honoring the `commitWithin` if it was provided