### PR TITLE
Set wt=json in _select only if the user has not set it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 solr*.tgz
 solr-app
 solr
+solr.*
+venv
+logs
+__pycache__

--- a/pysolr.py
+++ b/pysolr.py
@@ -464,8 +464,8 @@ class Solr(object):
         :param handler: defaults to self.search_handler (fallback to 'select')
         :return:
         """
-        # specify json encoding of results
-        params["wt"] = "json"
+        # Returns json docs unless otherwise specified
+        params.setdefault("wt", "json")
         custom_handler = handler or self.search_handler
         handler = "select"
         if custom_handler:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -366,6 +366,11 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
         self.assertEqual(len(resp_data["response"]["docs"]), 2)
         self.assertIn("nextCursorMark", resp_data)
 
+    def test__select_wt_xml(self):
+        resp_body = self.solr._select({"q": "doc", "wt": "xml"})
+        response = ElementTree.fromstring(resp_body)
+        self.assertEqual(int(response.find('result').get("numFound")), 3)
+
     def test__mlt(self):
         resp_body = self.solr._mlt({"q": "id:doc_1", "mlt.fl": "title"})
         resp_data = json.loads(resp_body)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -369,7 +369,7 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
     def test__select_wt_xml(self):
         resp_body = self.solr._select({"q": "doc", "wt": "xml"})
         response = ElementTree.fromstring(resp_body)
-        self.assertEqual(int(response.find('result').get("numFound")), 3)
+        self.assertEqual(int(response.find("result").get("numFound")), 3)
 
     def test__mlt(self):
         resp_body = self.solr._mlt({"q": "id:doc_1", "mlt.fl": "title"})


### PR DESCRIPTION
The `_select` method will set the solr query param `wt=json` regardless of whether the user has set it or not. Now I've made it happen only if the user does not specify the `wt` param. 
