### PR TITLE
Avoid running tests under PyPy on GitHub Actions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,13 +5,21 @@ on:
   pull_request:
     branches: [master]
 jobs:
-  ruff:  # https://beta.ruff.rs
+  ruff: # https://docs.astral.sh/ruff/editor-integrations/#github-actions
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - run: pip install --user "codespell[toml]" ruff
-    - run: codespell
-    - run: ruff --format=github .
+      - uses: actions/checkout@v3
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - run: |
+          python -m pip install --upgrade pip
+          pip install --user "codespell[toml]" ruff
+      - run: codespell
+      - run: ruff check .
+        env: 
+          RUFF_FORMAT: github
 
   tox:
     needs: ruff

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,7 +18,7 @@ jobs:
           pip install --user "codespell[toml]" ruff
       - run: codespell
       - run: ruff check .
-        env: 
+        env:
           RUFF_FORMAT: github
 
   tox:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', 'pypy3.10']
+        python: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
                 - tomli
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.0.292
+      rev: v0.1.0
       hooks:
           - id: ruff
 
@@ -49,6 +49,6 @@ repos:
           - id: pyproject-fmt
 
     - repo: https://github.com/abravalheri/validate-pyproject
-      rev: v0.14
+      rev: v0.15
       hooks:
           - id: validate-pyproject


### PR DESCRIPTION
Until we can identify what makes the connection to Solr unstable in the GitHub Actions environment, this is less important than not normalizing CI failures.
