### PR TITLE
Fix DeprecationWarning from pkg_resources

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,6 +61,10 @@ Changes
   IMPORTANT: If you are upgrading to this version and need to keep committing by default,
   change the Solr objects to have ``always_commit=True``.
 
+- `pysolr.version_info` and `pysolr.pkg_distribution` have been removed. [Craig de Stigter]
+
+- Added dependency on `importlib_metadata` for Python < 3.8 [Craig de Stigter]
+
 Fix
 ~~~
 
@@ -119,6 +123,10 @@ Other
 - Tox: run SolrCloud tests (parity with Travis CI) [Chris Adams]
 
 - Update project URL. [Chris Adams]
+
+- Fixed DeprecationWarning from `pkg_resources` on Python 3.10+ [Craig de Stigter]
+
+  Closes #464
 
 v3.5.0 (2016-05-24)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,7 @@
 [tool.ruff]
+target-version = "py37"
+
+[tool.ruff.lint]
 select = [
   "A",      # flake8-builtins
   "B",      # flake8-bugbear
@@ -69,19 +72,18 @@ ignore = [
   "S314",
   "S603",
 ]
-target-version = "py37"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 16
 
-[tool.ruff.pylint]
+[tool.ruff.lint.pylint]
 allow-magic-value-types = ["int", "str"]
 max-args = 12
 max-branches = 20
 max-returns = 7
 max-statements = 54
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]
 
 [tool.codespell]

--- a/pysolr.py
+++ b/pysolr.py
@@ -11,7 +11,14 @@ import time
 from xml.etree import ElementTree
 
 import requests
-from pkg_resources import DistributionNotFound, get_distribution, parse_version
+
+try:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _get_version
+except ImportError:
+    # python < 3.8
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _get_version
 
 try:
     from kazoo.client import KazooClient, KazooState
@@ -65,12 +72,9 @@ __author__ = "Daniel Lindsley, Joseph Kocherhans, Jacob Kaplan-Moss, Thomas Ried
 __all__ = ["Solr"]
 
 try:
-    pkg_distribution = get_distribution(__name__)
-    __version__ = pkg_distribution.version
-    version_info = pkg_distribution.parsed_version
-except DistributionNotFound:
+    __version__ = _get_version(__name__)
+except PackageNotFoundError:
     __version__ = "0.0.dev0"
-    version_info = parse_version(__version__)
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,11 @@ setup(
     ],
     url="https://github.com/django-haystack/pysolr/",
     license="BSD",
-    install_requires=["requests>=2.9.1", "setuptools"],
+    install_requires=[
+        "requests>=2.9.1",
+        "setuptools",
+        "importlib_metadata; python_version<'3.8'",
+    ],
     extras_require={"solrcloud": ["kazoo>=2.5.0"]},
     setup_requires=["setuptools_scm"],
 )


### PR DESCRIPTION
Use `importlib.metadata` (python 3.8+) or `importlib_metadata` instead.

> Please confirm that [the tests pass](https://github.com/django-haystack/pysolr/blob/master/README.rst#running-tests) locally

I get [two test fails on py312](https://gist.github.com/craigds/06e50d158cf8141e00acf142d68a7e32), but they don't seem related - errors connecting to solr. Other environments pass

Fixes #464 