### PR TITLE
[REMOVE] - tests: remove duplicate get_solr method from SolrTestCase class.

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -256,13 +256,6 @@ class SolrTestCase(unittest.TestCase, SolrTestCaseMixin):
             URL, "%s/%s" % (self.solr.url.replace("/core0", ""), path)
         )
 
-    def get_solr(self, collection, timeout=60, always_commit=False):
-        return Solr(
-            "http://localhost:8983/solr/%s" % collection,
-            timeout=timeout,
-            always_commit=always_commit,
-        )
-
     def test_init(self):
         self.assertEqual(self.solr.url, "http://localhost:8983/solr/core0")
         self.assertIsInstance(self.solr.decoder, json.JSONDecoder)


### PR DESCRIPTION
## Summary

This PR removes a duplicate `get_solr` method definition from the `SolrTestCase` class in `tests/test_client.py`.

## Details

The `get_solr` method is already defined in the inherited `SolrTestCaseMixin`:

```python
class SolrTestCaseMixin(object):
    def get_solr(self, collection, timeout=60, always_commit=False):
        return Solr(
            "http://localhost:8983/solr/%s" % collection,
            timeout=timeout,
            always_commit=always_commit,
        )
````

Since `SolrTestCase` inherits from `SolrTestCaseMixin`, having the same method redefined inside `SolrTestCase` was redundant.
This commit removes the duplicate definition from `SolrTestCase`.

## Why?

* Avoids code duplication
* Keeps tests easier to maintain
* Reduces the chance of inconsistency if the method changes in the future

## Impact

* **No functional changes** — tests still work as expected
* Simplifies the test class by relying on the mixin’s existing implementation