### PR TITLE
fix: Remove setup.cfg to eliminate Python 2 tag from distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[wheel]
-universal = 1


### PR DESCRIPTION
### Summary

This PR removes the `setup.cfg` file, which currently defines:

```ini
[wheel]
universal = 1
```

The PySolr project (current versions) does **not** support Python 2, so this configuration is no longer needed.

Refer to the official docs: [Distributing Packages Using Setuptools](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#wheels)

---

### Test Comparison

**Wheel file name changes:**

* **With `setup.cfg`:** `pysolr-0.1.dev624+g4ee90d138-py2.py3-none-any`
* **Without `setup.cfg`:** `pysolr-0.1.dev624+g4ee90d138.d20251110-py3-none-any`


Screenshot Difference using [Meld](https://meldmerge.org/) :

<img width="1361" height="285" alt="before-after" src="https://github.com/user-attachments/assets/954d8d76-bdb9-4e70-bda7-4adb0d724bae" />

* **Left side:** with `setup.cfg` wheel distribution
* **Right side:** without `setup.cfg` wheel distribution