### PR TITLE
feat: Configure Ruff linter pre-commit to perform write operations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,9 @@ repos:
     - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: v0.14.3
       hooks:
+          # Run the linter.
           - id: ruff-check
+            args: [ --fix ]
 
     - repo: https://github.com/psf/black-pre-commit-mirror
       rev: 25.9.0


### PR DESCRIPTION
## Summary

Allow Ruff linter in pre-commit to automatically fix lint issues by writing files.

After running pre-commit, if any files have lint issues, this will automatically fix them.  

Now we only need to run `git add .` and re-run pre-commit; this time everything will pass,  
instead of running `ruff check --fix .` again.