### PR TITLE
Format Python code with ruff-format instead of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,14 +38,9 @@ repos:
     - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: v0.14.3
       hooks:
-          # Run the linter.
           - id: ruff-check
             args: [ --fix ]
-
-    - repo: https://github.com/psf/black-pre-commit-mirror
-      rev: 25.9.0
-      hooks:
-          - id: black
+          - id: ruff-format
 
     - repo: https://github.com/tox-dev/pyproject-fmt
       rev: v2.11.0


### PR DESCRIPTION
Faster yet highly compatible
* https://docs.astral.sh/ruff/formatter