### PR TITLE
refactor: Remove legacy safe_urlencode wrapper function from the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Basic usage looks like:
 import pysolr
 
 # Create a client instance. The timeout and authentication options are not required.
-# Solr URL format: http://host:port/solr/<CORE_NAME>
+# Solr URL format: http://host:port/solr/<core_name>
 solr = pysolr.Solr("http://localhost:8983/solr/my_core", always_commit=True, [timeout=10], [auth=<type of authentication>])
 
 # Note that auto_commit defaults to False for performance. You can set

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ import pysolr
 
 # Create a client instance. The timeout and authentication options are not required.
 # Solr URL format: http://host:port/solr/<core_name>
-solr = pysolr.Solr("http://localhost:8983/solr/my_core", always_commit=True, [timeout=10], [auth=<type of authentication>])
+solr = pysolr.Solr("http://localhost:8983/solr/<core_name>", always_commit=True, [timeout=10], [auth=<type of authentication>])
 
 # Note that auto_commit defaults to False for performance. You can set
 # `auto_commit=True` to have commands always update the index immediately, make
@@ -162,14 +162,14 @@ Simply point the URL to the index core:
 
 ```python
 # Setup a Solr instance. The timeout is optional.
-solr = pysolr.Solr("http://localhost:8983/solr/my_core", timeout=10)
+solr = pysolr.Solr("http://localhost:8983/solr/<core_name>", timeout=10)
 ```
 
 ### Custom Request Handlers
 
 ```python
 # Setup a Solr instance. The trailing slash is optional.
-solr = pysolr.Solr("http://localhost:8983/solr/my_core", search_handler="/autocomplete", use_qt_param=False)
+solr = pysolr.Solr("http://localhost:8983/solr/<core_name>", search_handler="/autocomplete", use_qt_param=False)
 ```
 
 If `use_qt_param` is `True` it is essential that the name of the handler
@@ -194,7 +194,7 @@ handler in `search` explicitly overrides the `search_handler` setting
 from requests_kerberos import HTTPKerberosAuth, OPTIONAL
 kerberos_auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL, sanitize_mutual_error_response=False)
 
-solr = pysolr.Solr("http://localhost:8983/solr/my_core", auth=kerberos_auth)
+solr = pysolr.Solr("http://localhost:8983/solr/<core_name>", auth=kerberos_auth)
 ```
 
 ```python
@@ -210,7 +210,7 @@ solr = pysolr.SolrCloud(zookeeper, "collection", auth=kerberos_auth)
 
 ```python
 # Setup a Solr instance in an https environment
-solr = pysolr.Solr("http://localhost:8983/solr/my_core", verify="path/to/cert.pem")
+solr = pysolr.Solr("http://localhost:8983/solr/<core_name>", verify="path/to/cert.pem")
 ```
 
 ```python
@@ -225,7 +225,7 @@ solr = pysolr.SolrCloud(zookeeper, "collection", verify="path/to/cert.perm")
 ```python
 # Setup a Solr instance. The trailing slash is optional.
 # All requests to Solr will be immediately committed because `always_commit=True`:
-solr = pysolr.Solr("http://localhost:8983/solr/my_core", search_handler="/autocomplete", always_commit=True)
+solr = pysolr.Solr("http://localhost:8983/solr/<core_name>", search_handler="/autocomplete", always_commit=True)
 ```
 
 `always_commit` signals to the Solr object to either commit or not

--- a/pysolr.py
+++ b/pysolr.py
@@ -110,16 +110,6 @@ def unescape_html(text):
     return re.sub(r"&#?\w+;", fixup, text)
 
 
-def safe_urlencode(params, doseq=False):
-    """
-    URL-encode parameters using UTF-8 encoding.
-
-    This is a wrapper around `urllib.parse.urlencode` that ensures
-    consistent UTF-8 handling for all parameter values.
-    """
-    return urlencode(params, doseq)
-
-
 def clean_xml_string(s):
     """
     Cleans string from invalid xml chars
@@ -230,12 +220,12 @@ class Solr:
 
     Usage::
 
-        solr = pysolr.Solr('http://localhost:8983/solr')
+        solr = pysolr.Solr('http://localhost:8983/solr/my_core')
         # With a 10 second timeout.
-        solr = pysolr.Solr('http://localhost:8983/solr', timeout=10)
+        solr = pysolr.Solr('http://localhost:8983/solr/my_core', timeout=10)
 
         # with a dict as a default results class instead of pysolr.Results
-        solr = pysolr.Solr('http://localhost:8983/solr', results_cls=dict)
+        solr = pysolr.Solr('http://localhost:8983/solr/my_core', results_cls=dict)
 
     """
 
@@ -392,7 +382,7 @@ class Solr:
             else:
                 handler = custom_handler
 
-        params_encoded = safe_urlencode(params, True)
+        params_encoded = urlencode(params, doseq=True)
 
         if len(params_encoded) < 1024:
             # Typical case.
@@ -446,7 +436,7 @@ class Solr:
         path_handler = handler
         if self.use_qt_param:
             path_handler = "select"
-            query_vars.append("qt=%s" % safe_urlencode(handler, True))
+            query_vars.append("qt=%s" % urlencode(handler, doseq=True))
 
         path = path_handler
 
@@ -1208,7 +1198,7 @@ class Solr:
 
         """
         params = kwargs
-        params_encoded = safe_urlencode(params, True)
+        params_encoded = urlencode(params, doseq=True)
 
         if len(params_encoded) < 1024:
             # Typical case.

--- a/pysolr.py
+++ b/pysolr.py
@@ -220,12 +220,12 @@ class Solr:
 
     Usage::
 
-        solr = pysolr.Solr('http://localhost:8983/solr/my_core')
+        solr = pysolr.Solr('http://localhost:8983/solr/<core_name>')
         # With a 10 second timeout.
-        solr = pysolr.Solr('http://localhost:8983/solr/my_core', timeout=10)
+        solr = pysolr.Solr('http://localhost:8983/solr/<core_name>', timeout=10)
 
         # with a dict as a default results class instead of pysolr.Results
-        solr = pysolr.Solr('http://localhost:8983/solr/my_core', results_cls=dict)
+        solr = pysolr.Solr('http://localhost:8983/solr/<core_name>', results_cls=dict)
 
     """
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,5 @@
 from unittest.mock import Mock
-from urllib.parse import unquote_plus
+from urllib.parse import unquote_plus, urlencode
 
 import pytest
 import requests
@@ -10,7 +10,6 @@ from pysolr import (
     clean_xml_string,
     force_bytes,
     force_unicode,
-    safe_urlencode,
     sanitize,
     unescape_html,
 )
@@ -26,17 +25,15 @@ class TestUtils:
             unescape_html("Hello &doesnotexist; world") == "Hello &doesnotexist; world"
         )
 
-    def test_safe_urlencode(self):
+    def test_urlencode(self):
         assert (
-            force_unicode(
-                unquote_plus(safe_urlencode({"test": "Hello ☃! Helllo world!"}))
-            )
+            force_unicode(unquote_plus(urlencode({"test": "Hello ☃! Helllo world!"})))
             == "test=Hello ☃! Helllo world!"
         )
         assert (
             force_unicode(
                 unquote_plus(
-                    safe_urlencode({"test": ["Hello ☃!", "Helllo world!"]}, True)
+                    urlencode({"test": ["Hello ☃!", "Helllo world!"]}, doseq=True)
                 )
             )
             == "test=Hello \u2603!&test=Helllo world!"
@@ -44,7 +41,7 @@ class TestUtils:
         assert (
             force_unicode(
                 unquote_plus(
-                    safe_urlencode({"test": ("Hello ☃!", "Helllo world!")}, True)
+                    urlencode({"test": ("Hello ☃!", "Helllo world!")}, doseq=True)
                 )
             )
             == "test=Hello \u2603!&test=Helllo world!"


### PR DESCRIPTION
## Description

1. Remove the legacy `safe_urlencode` wrapper around `urllib.parse.urlencode`.
2. Fix the Solr class docstring URL, which previously did not include the core name, it has now been updated to include it. The README has been updated accordingly.