### PR TITLE
feat(api)!: remove unsupported load() api method from SolrCoreAdmin

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -1242,7 +1242,6 @@ class SolrCoreAdmin:
        5. ALIAS
        6. SWAP
        7. UNLOAD
-       8. LOAD (not currently implemented)
     """
 
     def __init__(self, url, timeout=60, auth=None, verify=True, session=None):
@@ -1389,9 +1388,6 @@ class SolrCoreAdmin:
         """
         params = {"action": "UNLOAD", "core": core}
         return self._send_request(self.url, params=params)
-
-    def load(self, core):
-        raise NotImplementedError("Solr 1.4 and below do not support this operation.")
 
 
 # Using two-tuples to preserve order.

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -118,10 +118,6 @@ class TestSolrCoreAdmin:
 
         assert result["responseHeader"]["status"] == 0
 
-    def test_load(self):
-        with pytest.raises(NotImplementedError):
-            self.solr_admin.load("wheatley")
-
     def test_status__nonexistent_core_returns_empty_response(self):
         """Test that requesting status for a missing core returns an empty response."""
         result = self.solr_admin.status(core="not_exists")


### PR DESCRIPTION
## Description

Apache Solr CoreAdmin API: [docs](https://solr.apache.org/guide/solr/9_0/configuration-guide/coreadmin-api.html)

**[BREAKING!]**
- Remove unsupported `load()` method from `SolrCoreAdmin`, as it is not part of the official Solr CoreAdmin API.
- Remove the related test cases from `tests/test_admin.py`