### PR TITLE
chore(logging): use built-in logging.NullHandler for default logger

### DIFF
--- a/pysolr.py
+++ b/pysolr.py
@@ -40,19 +40,17 @@ VALID_XML_CHARS_REGEX = re.compile(
 )
 
 
-class NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
-
-
-# Add the ``NullHandler`` to avoid logging by default while still allowing
-# others to attach their own handlers.
+# ---------------------------
+# Logging
+# ---------------------------
 LOG = logging.getLogger("pysolr")
-h = NullHandler()
-LOG.addHandler(h)
+
+# Add a ``NullHandler`` to avoid logging by default.
+# Users can configure logging or enable debug output via `DEBUG_PYSOLR`.
+LOG.addHandler(logging.NullHandler())
 
 # For debugging...
-if os.environ.get("DEBUG_PYSOLR", "").lower() in ("true", "1"):
+if os.environ.get("DEBUG_PYSOLR", "").lower() in {"true", "1"}:
     LOG.setLevel(logging.DEBUG)
     stream = logging.StreamHandler()
     LOG.addHandler(stream)


### PR DESCRIPTION
## Description

Python already provides a built-in black hole logger `logging.NullHandler`, just like our universe does. 
Use it instead of a custom implementation. 

More: [official documentation](https://docs.python.org/3/library/logging.handlers.html#nullhandler)

_Illustration: `logging.NullHandler` acts like a black hole for log messages._
<img width="640" height="400" alt="blackhole" src="https://github.com/user-attachments/assets/c2b506b6-2532-4eb2-9a60-4eed40ee5121" />
